### PR TITLE
feat: respect `input` option in the form of a record

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -13,13 +13,11 @@ import type { Plugin } from 'rolldown'
 
 export function createGeneratePlugin({
   isolatedDeclaration,
-  inputAlias,
+  inputAlias = {},
   external,
 }: Pick<Options, 'external' | 'isolatedDeclaration' | 'inputAlias'>): Plugin {
   const dtsMap = new Map<string, string>()
-  const inputAliasMap = new Map<string, string>(
-    Object.entries(inputAlias || {}),
-  )
+  const inputAliasMap = new Map<string, string>(Object.entries(inputAlias))
 
   let inputOption: Record<string, string> | undefined
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -57,11 +57,10 @@ export function createGeneratePlugin({
         if (mod?.isEntry) {
           let fileName = basename(dtsId)
 
-          if (inputAliasMap.has(dtsId)) {
-            fileName = inputAliasMap.get(dtsId)!
-          }
           if (inputAliasMap.has(fileName)) {
             fileName = inputAliasMap.get(fileName)!
+          } else if (inputAliasMap.has(dtsId)) {
+            fileName = inputAliasMap.get(dtsId)!
           }
 
           this.emitFile({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

According to [rollup's documentation](https://rollupjs.org/configuration-options/#input):

> When using the object form, the [name] portion of the file name will be the name of the object property while for the array form, it will be the file name of the entry point.

This PR adds support for this feature as a fallback when `inputAlias` in the plugin options are not specified or not matched.

Currently only the feature is implemented, I will add test cases later if you think this feature is necessary.

### Linked Issues

None

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
