### PR TITLE
feat!: remove `inputAlias` option, enforce use of `input` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can find a real demo in [here](./rolldown.config.ts).
 
 ## Options
 
-````ts
+```ts
 interface Options {
   /**
    * When entries are `.d.ts` files (instead of `.ts` files), this option should be set to `true`.
@@ -58,21 +58,11 @@ interface Options {
    * This option is enabled when `isolatedDeclaration` in `tsconfig.json` is set to `true`.
    */
   isolatedDeclaration?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
-  /**
-   * dts file name alias `{ [filename]: path }`
-   *
-   * @example
-   * ```ts
-   * inputAlias: {
-   *   'foo.d.ts': 'foo/index.d.ts',
-   * }
-   */
-  inputAlias?: Record<string, string>
 
   /** Resolve external types used in dts files from `node_modules` */
   resolve?: boolean | (string | RegExp)[]
 }
-````
+```
 
 ## Differences from `rollup-plugin-dts`
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -143,8 +143,7 @@ export function createGeneratePlugin({
         })
 
         if (isEntry) {
-          const name: string | undefined = inputAliasMap.get(id)
-
+          const name = inputAliasMap.get(id)
           this.emitFile({
             type: 'chunk',
             id: dtsId,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -148,7 +148,7 @@ export function createGeneratePlugin({
           this.emitFile({
             type: 'chunk',
             id: dtsId,
-            fileName: name ? `${name}.d.ts` : undefined,
+            name: name ? `${name}.d` : undefined,
           })
 
           if (emitDtsOnly) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,22 +31,6 @@ export interface Options {
    * This option is enabled when `isolatedDeclaration` in `tsconfig.json` is set to `true`.
    */
   isolatedDeclaration?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
-  /**
-   * An object mapping names to TypeScript source file paths. { [entryName: string]: string }
-   *
-   * @example
-   *
-   * The following config will generate at least two entry chunks with the names
-   * `a.d.ts` and `b/index.d.ts`
-   *
-   * ```ts
-   * inputAlias: {
-   *   'a': 'src/main-a.ts',
-   *   'b/index': 'src/main-b.ts'
-   * }
-   * ```
-   */
-  inputAlias?: { [entryName: string]: string }
 
   /** Resolve external types used in dts files from `node_modules` */
   resolve?: boolean | (string | RegExp)[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,15 +32,21 @@ export interface Options {
    */
   isolatedDeclaration?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
   /**
-   * dts file name alias `{ [filename]: path }`
+   * An object mapping names to TypeScript source file paths. { [entryName: string]: string }
    *
    * @example
+   *
+   * The following config will generate at least two entry chunks with the names
+   * `a.d.ts` and `b/index.d.ts`
+   *
    * ```ts
    * inputAlias: {
-   *   'foo.d.ts': 'foo/index.d.ts',
+   *   'a': 'src/main-a.ts',
+   *   'b/index': 'src/main-b.ts'
    * }
+   * ```
    */
-  inputAlias?: Record<string, string>
+  inputAlias?: { [entryName: string]: string }
 
   /** Resolve external types used in dts files from `node_modules` */
   resolve?: boolean | (string | RegExp)[]

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,104 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`explicit input alias 1`] = `
+"// input2.d-BunDIF-p.d.ts
+
+//#region shared.d.ts
+interface Shared {
+    shared: string;
+}
+declare const shared: Shared;
+
+//#endregion
+//#region input2.d.ts
+interface Input2 extends Shared {
+    input2: string;
+}
+declare const input2: Input2;
+
+//#endregion
+export { Input2, input2 };
+// output1.d.ts
+import { Input2 } from "./input2.d-BunDIF-p.js";
+
+//#region input1.d.ts
+interface Input1 extends Input2 {
+    input1: string;
+}
+declare const input1: Input1;
+
+//#endregion
+export { Input1, input1 };
+// output2/index.d.ts
+import { Input2, input2 } from "../input2.d-BunDIF-p.js";
+
+export { Input2, input2 };"
+`;
+
+exports[`implicit input alias 1`] = `
+"// input2-eM-jH71Q.js
+
+//#region shared.ts
+const shared = { shared: "shared" };
+
+//#endregion
+//#region input2.ts
+const input2 = {
+	...shared,
+	input2: "input2"
+};
+
+//#endregion
+export { input2 };
+// input2.d-D6mB_nrs.d.ts
+
+//#region shared.d.ts
+interface Shared {
+    shared: string;
+}
+declare const shared: Shared;
+
+//#endregion
+//#region input2.d.ts
+interface Input2 extends Shared {
+    input2: string;
+}
+declare const input2: Input2;
+
+//#endregion
+export { Input2, input2 as input2$1 };
+// output1.d.ts
+import { Input2 } from "./input2.d-D6mB_nrs.js";
+
+//#region input1.d.ts
+interface Input1 extends Input2 {
+    input1: string;
+}
+declare const input1: Input1;
+
+//#endregion
+export { Input1, input1 };
+// output1.js
+import { input2 } from "./input2-eM-jH71Q.js";
+
+//#region input1.ts
+const input1 = {
+	...input2,
+	input1: "input1"
+};
+
+//#endregion
+export { input1 };
+// output2/index.d.ts
+import { Input2, input2$1 as input2 } from "../input2.d-D6mB_nrs.js";
+
+export { Input2, input2 };
+// output2/index.js
+import { input2 } from "../input2-eM-jH71Q.js";
+
+export { input2 };"
+`;
+
 exports[`resolve dependencies 1`] = `
 "// resolve-dep.d.ts
 import MagicString, { MagicStringOptions, OverwriteOptions } from "magic-string";

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,41 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`explicit input alias 1`] = `
-"// input2.d-BunDIF-p.d.ts
-
-//#region shared.d.ts
-interface Shared {
-    shared: string;
-}
-declare const shared: Shared;
-
-//#endregion
-//#region input2.d.ts
-interface Input2 extends Shared {
-    input2: string;
-}
-declare const input2: Input2;
-
-//#endregion
-export { Input2, input2 };
-// output1.d.ts
-import { Input2 } from "./input2.d-BunDIF-p.js";
-
-//#region input1.d.ts
-interface Input1 extends Input2 {
-    input1: string;
-}
-declare const input1: Input1;
-
-//#endregion
-export { Input1, input1 };
-// output2/index.d.ts
-import { Input2, input2 } from "../input2.d-BunDIF-p.js";
-
-export { Input2, input2 };"
-`;
-
-exports[`implicit input alias 1`] = `
+exports[`input alias 1`] = `
 "// input2-eM-jH71Q.js
 
 //#region shared.ts

--- a/tests/fixtures/alias/input1.ts
+++ b/tests/fixtures/alias/input1.ts
@@ -1,0 +1,10 @@
+import { Input2, input2 } from './input2'
+
+export interface Input1 extends Input2 {
+  input1: string
+}
+
+export const input1: Input1 = {
+  ...input2,
+  input1: 'input1',
+}

--- a/tests/fixtures/alias/input2.ts
+++ b/tests/fixtures/alias/input2.ts
@@ -1,0 +1,10 @@
+import { Shared, shared } from './shared'
+
+export interface Input2 extends Shared {
+  input2: string
+}
+
+export const input2: Input2 = {
+  ...shared,
+  input2: 'input2',
+}

--- a/tests/fixtures/alias/shared.ts
+++ b/tests/fixtures/alias/shared.ts
@@ -1,0 +1,7 @@
+export interface Shared {
+  shared: string
+}
+
+export const shared: Shared = {
+  shared: 'shared',
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,8 +38,8 @@ test('resolve dependencies', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
-// Test implicit alias mapping based on rollup input option
-test('implicit input alias', async () => {
+// Test alias mapping based on rolldown input option
+test('input alias', async () => {
   const root = path.resolve(dirname, 'fixtures/alias')
   const { snapshot, chunks } = await rolldownBuild(
     null!,
@@ -67,40 +67,6 @@ test('implicit input alias', async () => {
   expect(fileNames).toContain('output1.js')
   expect(fileNames).toContain('output2/index.d.ts')
   expect(fileNames).toContain('output2/index.js')
-
-  expect(snapshot).toMatchSnapshot()
-})
-
-// Test explicit input alias mapping via plugin options
-test('explicit input alias', async () => {
-  const root = path.resolve(dirname, 'fixtures/alias')
-  const { snapshot, chunks } = await rolldownBuild(
-    null!,
-    [
-      dts({
-        emitDtsOnly: true, // Only generate DTS files
-        compilerOptions: {},
-        isolatedDeclaration: false,
-        // A mapping from output chunk names to input files. This mapping should
-        // only be used in DTS outputs.
-        inputAlias: {
-          output1: 'input1.ts',
-          'output2/index': 'input2.ts',
-        },
-      }),
-    ],
-    {
-      cwd: root,
-      // For JS outputs, input files are provided directly without any alias
-      // mapping.
-      input: ['input1.ts', 'input2.ts'],
-    },
-  )
-  const fileNames = chunks.map((chunk) => chunk.fileName).sort()
-
-  // Verify DTS files are generated at the correct paths
-  expect(fileNames).toContain('output1.d.ts')
-  expect(fileNames).toContain('output2/index.d.ts')
 
   expect(snapshot).toMatchSnapshot()
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,19 +38,22 @@ test('resolve dependencies', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+// Test implicit alias mapping based on rollup input option
 test('implicit input alias', async () => {
   const root = path.resolve(dirname, 'fixtures/alias')
   const { snapshot, chunks } = await rolldownBuild(
     null!,
     [
       dts({
-        emitDtsOnly: false,
+        emitDtsOnly: false, // Generate both JS and DTS files
         compilerOptions: {},
         isolatedDeclaration: false,
       }),
     ],
     {
       cwd: root,
+      // A mapping from output chunk names to input files. This mapping should
+      // be used in both JS and DTS outputs.
       input: {
         output1: 'input1.ts',
         'output2/index': 'input2.ts',
@@ -68,15 +71,18 @@ test('implicit input alias', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+// Test explicit input alias mapping via plugin options
 test('explicit input alias', async () => {
   const root = path.resolve(dirname, 'fixtures/alias')
   const { snapshot, chunks } = await rolldownBuild(
     null!,
     [
       dts({
-        emitDtsOnly: true,
+        emitDtsOnly: true, // Only generate DTS files
         compilerOptions: {},
         isolatedDeclaration: false,
+        // A mapping from output chunk names to input files. This mapping should
+        // only be used in DTS outputs.
         inputAlias: {
           output1: 'input1.ts',
           'output2/index': 'input2.ts',
@@ -85,11 +91,14 @@ test('explicit input alias', async () => {
     ],
     {
       cwd: root,
+      // For JS outputs, input files are provided directly without any alias
+      // mapping.
       input: ['input1.ts', 'input2.ts'],
     },
   )
   const fileNames = chunks.map((chunk) => chunk.fileName).sort()
 
+  // Verify DTS files are generated at the correct paths
   expect(fileNames).toContain('output1.d.ts')
   expect(fileNames).toContain('output2/index.d.ts')
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,6 +38,64 @@ test('resolve dependencies', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+test('implicit input alias', async () => {
+  const root = path.resolve(dirname, 'fixtures/alias')
+  const { snapshot, chunks } = await rolldownBuild(
+    null!,
+    [
+      dts({
+        emitDtsOnly: false,
+        compilerOptions: {},
+        isolatedDeclaration: false,
+      }),
+    ],
+    {
+      cwd: root,
+      input: {
+        output1: 'input1.ts',
+        'output2/index': 'input2.ts',
+      },
+    },
+  )
+  const fileNames = chunks.map((chunk) => chunk.fileName).sort()
+
+  // The JS output and DTS output should have the same structure
+  expect(fileNames).toContain('output1.d.ts')
+  expect(fileNames).toContain('output1.js')
+  expect(fileNames).toContain('output2/index.d.ts')
+  expect(fileNames).toContain('output2/index.js')
+
+  expect(snapshot).toMatchSnapshot()
+})
+
+test('explicit input alias', async () => {
+  const root = path.resolve(dirname, 'fixtures/alias')
+  const { snapshot, chunks } = await rolldownBuild(
+    null!,
+    [
+      dts({
+        emitDtsOnly: true,
+        compilerOptions: {},
+        isolatedDeclaration: false,
+        inputAlias: {
+          output1: 'input1.ts',
+          'output2/index': 'input2.ts',
+        },
+      }),
+    ],
+    {
+      cwd: root,
+      input: ['input1.ts', 'input2.ts'],
+    },
+  )
+  const fileNames = chunks.map((chunk) => chunk.fileName).sort()
+
+  expect(fileNames).toContain('output1.d.ts')
+  expect(fileNames).toContain('output2/index.d.ts')
+
+  expect(snapshot).toMatchSnapshot()
+})
+
 test('isolated declaration error', async () => {
   const error = await rolldownBuild(
     path.resolve(dirname, 'fixtures/isolated-decl-error.ts'),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

1. Update `inputAlias`'s shape so that it can accepts the same object as rollup/rolldown's [`input`](https://rollupjs.org/configuration-options/#input) option. 
2. Add some tests case for the `inputAlias` option to make sure it's working

### Linked Issues

N/A


### Additional context

This is a breaking change 

<!-- e.g. is there anything you'd like reviewers to focus on? -->
