### PR TITLE
fix!: rename option `isolatedDeclaration` to `isolatedDeclarations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ interface Options {
    *
    * This option is enabled when `isolatedDeclarations` in `compilerOptions` is set to `true`.
    */
-  isolatedDeclaration?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
+  isolatedDeclarations?:
+    | boolean
+    | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
 
   /** Resolve external types used in dts files from `node_modules` */
   resolve?: boolean | (string | RegExp)[]
@@ -79,7 +81,7 @@ interface Options {
 
 ### Isolated Declarations
 
-The plugin leverages Oxc's `isolatedDeclarations` to generate `.d.ts` files when `isolatedDeclaration` is enabled,
+The plugin leverages Oxc's `isolatedDeclarations` to generate `.d.ts` files when `isolatedDeclarations` is enabled,
 offering significantly faster performance compared to the `typescript` compiler.
 
 ### Single Build for ESM

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -31,12 +31,12 @@ export type DtsMap = Map<string, TsModule>
 export function createGeneratePlugin({
   tsconfig,
   compilerOptions,
-  isolatedDeclaration,
+  isolatedDeclarations,
   resolve = false,
   emitDtsOnly = false,
 }: Pick<
   Options,
-  | 'isolatedDeclaration'
+  | 'isolatedDeclarations'
   | 'resolve'
   | 'emitDtsOnly'
   | 'tsconfig'
@@ -60,14 +60,14 @@ export function createGeneratePlugin({
       }
     }
 
-    if (isolatedDeclaration == null) {
-      isolatedDeclaration = !!compilerOptions?.isolatedDeclarations
+    if (isolatedDeclarations == null) {
+      isolatedDeclarations = !!compilerOptions?.isolatedDeclarations
     }
-    if (isolatedDeclaration === true) {
-      isolatedDeclaration = {}
+    if (isolatedDeclarations === true) {
+      isolatedDeclarations = {}
     }
-    if (isolatedDeclaration && isolatedDeclaration.stripInternal == null) {
-      isolatedDeclaration.stripInternal = !!compilerOptions?.stripInternal
+    if (isolatedDeclarations && isolatedDeclarations.stripInternal == null) {
+      isolatedDeclarations.stripInternal = !!compilerOptions?.stripInternal
     }
   }
 
@@ -93,7 +93,7 @@ export function createGeneratePlugin({
         tsconfig: tsconfig ? (tsconfig as string) : undefined,
       })
 
-      if (!isolatedDeclaration) {
+      if (!isolatedDeclarations) {
         initTs()
       }
 
@@ -236,11 +236,11 @@ export function createGeneratePlugin({
         const { code, id, isEntry } = dtsMap.get(dtsId)!
         let dtsCode: string | undefined
 
-        if (isolatedDeclaration) {
+        if (isolatedDeclarations) {
           const result = oxcIsolatedDeclaration(
             id,
             code,
-            isolatedDeclaration === true ? {} : isolatedDeclaration,
+            isolatedDeclarations === true ? {} : isolatedDeclarations,
           )
           if (result.errors.length) {
             const [error] = result.errors

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,13 @@ export interface Options {
    *
    * This option is enabled when `isolatedDeclarations` in `compilerOptions` is set to `true`.
    */
+  isolatedDeclarations?:
+    | boolean
+    | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
+
+  /**
+   * @deprecated Use `isolatedDeclarations` instead.
+   */
   isolatedDeclaration?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
 
   /** Resolve external types used in dts files from `node_modules` */
@@ -49,6 +56,14 @@ export interface Options {
 }
 
 export function dts(options: Options = {}): Plugin[] {
+  // Compatibility with old `isolatedDeclaration` option name
+  if (options.isolatedDeclaration != null) {
+    console.warn(
+      '[rolldown-plugin-dts] `isolatedDeclaration` option is deprecated. Use `isolatedDeclarations` instead.',
+    )
+    options = { ...options, isolatedDeclarations: options.isolatedDeclaration }
+  }
+
   const plugins: Plugin[] = []
   if (!options.dtsInput) {
     plugins.push(createGeneratePlugin(options))

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,24 +46,11 @@ export interface Options {
     | boolean
     | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
 
-  /**
-   * @deprecated Use `isolatedDeclarations` instead.
-   */
-  isolatedDeclaration?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
-
   /** Resolve external types used in dts files from `node_modules` */
   resolve?: boolean | (string | RegExp)[]
 }
 
 export function dts(options: Options = {}): Plugin[] {
-  // Compatibility with old `isolatedDeclaration` option name
-  if (options.isolatedDeclaration != null) {
-    console.warn(
-      '[rolldown-plugin-dts] `isolatedDeclaration` option is deprecated. Use `isolatedDeclarations` instead.',
-    )
-    options = { ...options, isolatedDeclarations: options.isolatedDeclaration }
-  }
-
   const plugins: Plugin[] = []
   if (!options.dtsInput) {
     plugins.push(createGeneratePlugin(options))

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -42,7 +42,7 @@ test('typescript compiler', async () => {
           skipLibCheck: true,
           isolatedDeclarations: false,
         },
-        isolatedDeclaration: false,
+        isolatedDeclarations: false,
       }),
     ],
   )
@@ -55,7 +55,7 @@ test('resolve dependencies', async () => {
     [
       dts({
         resolve: ['magic-string-ast'],
-        isolatedDeclaration: true,
+        isolatedDeclarations: true,
         emitDtsOnly: true,
       }),
     ],
@@ -72,7 +72,7 @@ test('input alias', async () => {
       dts({
         emitDtsOnly: false, // Generate both JS and DTS files
         compilerOptions: {},
-        isolatedDeclaration: false,
+        isolatedDeclarations: false,
       }),
     ],
     {
@@ -102,7 +102,7 @@ test('isolated declaration error', async () => {
     [
       dts({
         emitDtsOnly: true,
-        isolatedDeclaration: true,
+        isolatedDeclarations: true,
       }),
     ],
   ).catch((error: any) => error)
@@ -118,7 +118,7 @@ test('paths', async () => {
     path.resolve(root, 'index.ts'),
     [
       dts({
-        isolatedDeclaration: true,
+        isolatedDeclarations: true,
         emitDtsOnly: true,
       }),
     ],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   platform: 'node',
   plugins: [
     dts({
-      isolatedDeclaration: true,
+      isolatedDeclarations: true,
     }),
   ],
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR renames the option `isolatedDeclaration` to `isolatedDeclarations` (notice the "s" at the end). This new name matches the naming in `tsconfig.json` ([document link](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations)).

I believe it can reduce potential misconfiguration when users copy `isolatedDeclarations` from `tsconfig.json` to `rolldown.config.js`, especially when type checking is not working (e.g., users don't have `defineConfig()` or they don't add the `// ts-check` comment in their `rolldown.config.js`).

~~For backward compatibility reason, the plugin still accepts the deprecated `isolatedDeclaration` option, and it will print a warning when it does so. We can remove the deprecated option in a future release.~~

Dropped `isolatedDeclaration` option.

### Linked Issues

N/A


### Additional context

N/A

<!-- e.g. is there anything you'd like reviewers to focus on? -->
