### PR TITLE
feat: experimental Vue SFC support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,14 @@
   },
   "peerDependencies": {
     "rolldown": "^1.0.0-beta.8-commit.534fde3",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "vue": {
       "optional": true
     }
   },
@@ -52,6 +56,8 @@
     "@babel/generator": "^7.27.1",
     "@babel/parser": "^7.27.2",
     "@babel/types": "^7.27.1",
+    "@volar/typescript": "^2.4.12",
+    "@vue/language-core": "^2.2.8",
     "ast-kit": "^2.0.0",
     "debug": "^4.4.0",
     "dts-resolver": "^1.1.2",
@@ -76,7 +82,8 @@
     "tsdown": "^0.11.1",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "vue": "^3.5.13"
   },
   "engines": {
     "node": ">=20.18.0"

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
   "peerDependencies": {
     "rolldown": "^1.0.0-beta.8-commit.534fde3",
     "typescript": "^5.0.0",
-    "vue": "^3.0.0"
+    "vue-tsc": "~2.2.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true
     },
-    "vue": {
+    "vue-tsc": {
       "optional": true
     }
   },
@@ -56,8 +56,6 @@
     "@babel/generator": "^7.27.1",
     "@babel/parser": "^7.27.2",
     "@babel/types": "^7.27.1",
-    "@volar/typescript": "^2.4.12",
-    "@vue/language-core": "^2.2.8",
     "ast-kit": "^2.0.0",
     "debug": "^4.4.0",
     "dts-resolver": "^1.1.2",
@@ -71,6 +69,8 @@
     "@types/debug": "^4.1.12",
     "@types/diff": "^7.0.2",
     "@types/node": "^22.15.17",
+    "@volar/typescript": "^2.4.13",
+    "@vue/language-core": "^2.2.10",
     "bumpp": "^10.1.0",
     "diff": "^7.0.0",
     "eslint": "^9.26.0",
@@ -83,7 +83,8 @@
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vitest": "^3.1.3",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-tsc": "^2.2.10"
   },
   "engines": {
     "node": ">=20.18.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@babel/types':
         specifier: ^7.27.1
         version: 7.27.1
+      '@volar/typescript':
+        specifier: ^2.4.12
+        version: 2.4.12
+      '@vue/language-core':
+        specifier: ^2.2.8
+        version: 2.2.8(typescript@5.8.3)
       ast-kit:
         specifier: ^2.0.0
         version: 2.0.0
@@ -91,6 +97,9 @@ importers:
       vitest:
         specifier: ^3.1.3
         version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.19.4)(yaml@2.7.1)
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.8.3)
 
 packages:
 
@@ -102,18 +111,35 @@ packages:
     resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@7.27.2':
     resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/types@7.27.0':
+    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.1':
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
@@ -863,6 +889,55 @@ packages:
   '@vitest/utils@3.1.3':
     resolution: {integrity: sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==}
 
+  '@volar/language-core@2.4.12':
+    resolution: {integrity: sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==}
+
+  '@volar/source-map@2.4.12':
+    resolution: {integrity: sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==}
+
+  '@volar/typescript@2.4.12':
+    resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
+
+  '@vue/compiler-core@3.5.13':
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+
+  '@vue/compiler-dom@3.5.13':
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+
+  '@vue/compiler-sfc@3.5.13':
+    resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
+
+  '@vue/compiler-ssr@3.5.13':
+    resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/language-core@2.2.8':
+    resolution: {integrity: sha512-rrzB0wPGBvcwaSNRriVWdNAbHQWSf0NlGqgKHK5mEkXpefjUlVRP62u03KvwZpvKVjRnBIQ/Lwre+Mx9N6juUQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/reactivity@3.5.13':
+    resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
+
+  '@vue/runtime-core@3.5.13':
+    resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
+
+  '@vue/runtime-dom@3.5.13':
+    resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
+
+  '@vue/server-renderer@3.5.13':
+    resolution: {integrity: sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==}
+    peerDependencies:
+      vue: 3.5.13
+
+  '@vue/shared@3.5.13':
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -879,6 +954,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1060,6 +1138,12 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -1141,6 +1225,10 @@ packages:
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1374,6 +1462,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1543,6 +1634,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -1914,6 +2009,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1998,6 +2096,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2485,11 +2586,22 @@ packages:
       jsdom:
         optional: true
 
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   vue-eslint-parser@10.1.3:
     resolution: {integrity: sha512-dbCBnd2e02dYWsXoqX5yKUZlOt+ExIpq7hmHKPb5ZqKcjf++Eo0hMseFTZMLKThrUk61m+Uv6A2YSBve6ZvuDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
+
+  vue@3.5.13:
+    resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
@@ -2556,13 +2668,26 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-validator-identifier@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
 
   '@babel/parser@7.27.2':
     dependencies:
       '@babel/types': 7.27.1
+
+  '@babel/types@7.27.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.27.1':
     dependencies:
@@ -3213,6 +3338,90 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@volar/language-core@2.4.12':
+    dependencies:
+      '@volar/source-map': 2.4.12
+
+  '@volar/source-map@2.4.12': {}
+
+  '@volar/typescript@2.4.12':
+    dependencies:
+      '@volar/language-core': 2.4.12
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.13':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@vue/shared': 3.5.13
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.13':
+    dependencies:
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/compiler-sfc@3.5.13':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@vue/compiler-core': 3.5.13
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+      postcss: 8.5.3
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.13':
+    dependencies:
+      '@vue/compiler-dom': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/language-core@2.2.8(typescript@5.8.3)':
+    dependencies:
+      '@volar/language-core': 2.4.12
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      alien-signals: 1.0.13
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.8.3
+
+  '@vue/reactivity@3.5.13':
+    dependencies:
+      '@vue/shared': 3.5.13
+
+  '@vue/runtime-core@3.5.13':
+    dependencies:
+      '@vue/reactivity': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/runtime-dom@3.5.13':
+    dependencies:
+      '@vue/reactivity': 3.5.13
+      '@vue/runtime-core': 3.5.13
+      '@vue/shared': 3.5.13
+      csstype: 3.1.3
+
+  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      vue: 3.5.13(typescript@5.8.3)
+
+  '@vue/shared@3.5.13': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -3230,6 +3439,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  alien-signals@1.0.13: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -3415,6 +3626,10 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  csstype@3.1.3: {}
+
+  de-indent@1.0.2: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -3473,6 +3688,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  entities@4.5.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -3808,6 +4025,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.7
@@ -3992,6 +4211,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  he@1.2.0: {}
 
   hookable@5.5.3: {}
 
@@ -4504,6 +4725,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.2.3: {}
@@ -4590,6 +4813,8 @@ snapshots:
   parse-statements@1.0.11: {}
 
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -5135,6 +5360,8 @@ snapshots:
       - tsx
       - yaml
 
+  vscode-uri@3.1.0: {}
+
   vue-eslint-parser@10.1.3(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       debug: 4.4.0
@@ -5147,6 +5374,16 @@ snapshots:
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
+
+  vue@3.5.13(typescript@5.8.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-sfc': 3.5.13
+      '@vue/runtime-dom': 3.5.13
+      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.8.3))
+      '@vue/shared': 3.5.13
+    optionalDependencies:
+      typescript: 5.8.3
 
   webpack-virtual-modules@0.6.2:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,12 +21,6 @@ importers:
       '@babel/types':
         specifier: ^7.27.1
         version: 7.27.1
-      '@volar/typescript':
-        specifier: ^2.4.12
-        version: 2.4.12
-      '@vue/language-core':
-        specifier: ^2.2.8
-        version: 2.2.8(typescript@5.8.3)
       ast-kit:
         specifier: ^2.0.0
         version: 2.0.0
@@ -64,6 +58,12 @@ importers:
       '@types/node':
         specifier: ^22.15.17
         version: 22.15.17
+      '@volar/typescript':
+        specifier: ^2.4.13
+        version: 2.4.13
+      '@vue/language-core':
+        specifier: ^2.2.10
+        version: 2.2.10(typescript@5.8.3)
       bumpp:
         specifier: ^10.1.0
         version: 10.1.0
@@ -100,6 +100,9 @@ importers:
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.8.3)
+      vue-tsc:
+        specifier: ^2.2.10
+        version: 2.2.10(typescript@5.8.3)
 
 packages:
 
@@ -892,11 +895,17 @@ packages:
   '@volar/language-core@2.4.12':
     resolution: {integrity: sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==}
 
+  '@volar/language-core@2.4.13':
+    resolution: {integrity: sha512-MnQJ7eKchJx5Oz+YdbqyFUk8BN6jasdJv31n/7r6/WwlOOv7qzvot6B66887l2ST3bUW4Mewml54euzpJWA6bg==}
+
   '@volar/source-map@2.4.12':
     resolution: {integrity: sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==}
 
-  '@volar/typescript@2.4.12':
-    resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
+  '@volar/source-map@2.4.13':
+    resolution: {integrity: sha512-l/EBcc2FkvHgz2ZxV+OZK3kMSroMr7nN3sZLF2/f6kWW66q8+tEL4giiYyFjt0BcubqJhBt6soYIrAPhg/Yr+Q==}
+
+  '@volar/typescript@2.4.13':
+    resolution: {integrity: sha512-Ukz4xv84swJPupZeoFsQoeJEOm7U9pqsEnaGGgt5ni3SCTa22m8oJP5Nng3Wed7Uw5RBELdLxxORX8YhJPyOgQ==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -913,8 +922,8 @@ packages:
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
 
-  '@vue/language-core@2.2.8':
-    resolution: {integrity: sha512-rrzB0wPGBvcwaSNRriVWdNAbHQWSf0NlGqgKHK5mEkXpefjUlVRP62u03KvwZpvKVjRnBIQ/Lwre+Mx9N6juUQ==}
+  '@vue/language-core@2.2.10':
+    resolution: {integrity: sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2595,6 +2604,12 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
+  vue-tsc@2.2.10:
+    resolution: {integrity: sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.13:
     resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
     peerDependencies:
@@ -3342,11 +3357,17 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.4.12
 
+  '@volar/language-core@2.4.13':
+    dependencies:
+      '@volar/source-map': 2.4.13
+
   '@volar/source-map@2.4.12': {}
 
-  '@volar/typescript@2.4.12':
+  '@volar/source-map@2.4.13': {}
+
+  '@volar/typescript@2.4.13':
     dependencies:
-      '@volar/language-core': 2.4.12
+      '@volar/language-core': 2.4.13
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
@@ -3385,7 +3406,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.2.8(typescript@5.8.3)':
+  '@vue/language-core@2.2.10(typescript@5.8.3)':
     dependencies:
       '@volar/language-core': 2.4.12
       '@vue/compiler-dom': 3.5.13
@@ -5374,6 +5395,12 @@ snapshots:
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
+
+  vue-tsc@2.2.10(typescript@5.8.3):
+    dependencies:
+      '@volar/typescript': 2.4.13
+      '@vue/language-core': 2.2.10(typescript@5.8.3)
+      typescript: 5.8.3
 
   vue@3.5.13(typescript@5.8.3):
     dependencies:

--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -124,6 +124,13 @@ export function createFakeJsPlugin({
 
       const sideEffect =
         stmt.type === 'TSModuleDeclaration' && stmt.kind !== 'namespace'
+      if (
+        sideEffect &&
+        id.endsWith('.vue.d.ts') &&
+        code.slice(stmt.start!, stmt.end!).includes('__VLS_')
+      ) {
+        continue
+      }
       const isDefaultExport = stmt.type === 'ExportDefaultDeclaration'
       const isDecl =
         isTypeOf(stmt, [

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -7,6 +7,7 @@ import {
   RE_JS,
   RE_NODE_MODULES,
   RE_TS,
+  RE_VUE,
 } from './utils/filename.ts'
 import { createOrGetTsModule, initTs, tscEmit } from './utils/tsc.ts'
 import type { OptionsResolved } from './index.ts'
@@ -96,7 +97,7 @@ export function createGeneratePlugin({
       order: 'pre',
       filter: {
         id: {
-          include: [RE_TS],
+          include: [RE_TS, RE_VUE],
           exclude: [RE_DTS, RE_NODE_MODULES],
         },
       },

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -30,9 +30,10 @@ export function createGeneratePlugin({
   compilerOptions = {},
   isolatedDeclarations,
   emitDtsOnly = false,
+  vue,
 }: Pick<
   OptionsResolved,
-  'compilerOptions' | 'isolatedDeclarations' | 'emitDtsOnly'
+  'compilerOptions' | 'isolatedDeclarations' | 'emitDtsOnly' | 'vue'
 >): Plugin {
   const dtsMap: DtsMap = new Map<string, TsModule>()
 
@@ -48,7 +49,7 @@ export function createGeneratePlugin({
   const inputAliasMap = new Map<string, string>()
   let programs: Ts.Program[] = []
 
-  if (!isolatedDeclarations) {
+  if (vue || !isolatedDeclarations) {
     initTs()
   }
 
@@ -138,7 +139,7 @@ export function createGeneratePlugin({
         let map: any
         debug('generate dts %s from %s', dtsId, id)
 
-        if (isolatedDeclarations) {
+        if (!vue && isolatedDeclarations) {
           const result = oxcIsolatedDeclaration(id, code, isolatedDeclarations)
           if (result.errors.length) {
             const [error] = result.errors
@@ -159,6 +160,7 @@ export function createGeneratePlugin({
             id,
             isEntry,
             dtsMap,
+            vue,
           )
           const result = tscEmit(module)
           if (result.error) {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -10,6 +10,7 @@ import {
   RE_VUE,
 } from './utils/filename.ts'
 import { createOrGetTsModule, initTs, tscEmit } from './utils/tsc.ts'
+import { createVueProgramFactory } from './utils/vue.ts'
 import type { OptionsResolved } from './index.ts'
 import type { Plugin } from 'rolldown'
 import type * as Ts from 'typescript'
@@ -51,6 +52,9 @@ export function createGeneratePlugin({
 
   if (vue || !isolatedDeclarations) {
     initTs()
+    if (vue) {
+      createVueProgramFactory()
+    }
   }
 
   return {
@@ -139,7 +143,7 @@ export function createGeneratePlugin({
         let map: any
         debug('generate dts %s from %s', dtsId, id)
 
-        if (!vue && isolatedDeclarations) {
+        if (isolatedDeclarations && !RE_VUE.test(id)) {
           const result = oxcIsolatedDeclaration(id, code, isolatedDeclarations)
           if (result.errors.length) {
             const [error] = result.errors

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,11 @@ export interface Options {
 
   /** Resolve external types used in dts files from `node_modules` */
   resolve?: boolean | (string | RegExp)[]
+
+  /**
+   * When `true`, the plugin will generate `.d.ts` via `vue-tsc`.
+   */
+  vue?: boolean
 }
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
@@ -103,6 +108,7 @@ export function resolveOptions({
   dtsInput = false,
   emitDtsOnly = false,
   resolve = false,
+  vue = false,
 }: Options): OptionsResolved {
   if (tsconfig === true || tsconfig == null) {
     const { config, path } = getTsconfig(cwd) || {}
@@ -146,5 +152,6 @@ export function resolveOptions({
     dtsInput,
     emitDtsOnly,
     resolve,
+    vue,
   }
 }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -6,6 +6,7 @@ import {
   RE_DTS,
   RE_NODE_MODULES,
   RE_TS,
+  RE_VUE,
 } from './utils/filename.ts'
 import type { OptionsResolved } from './index.ts'
 import type { Plugin } from 'rolldown'
@@ -41,7 +42,10 @@ export function createDtsResolvePlugin({
 
         let resolution = resolver(id, importer)
         resolution &&= path.normalize(resolution)
-        if (!resolution || !RE_TS.test(resolution)) {
+        if (
+          !resolution ||
+          (!RE_TS.test(resolution) && !RE_VUE.test(resolution))
+        ) {
           const result = await this.resolve(id, importer, options)
           if (!result || !RE_TS.test(result.id)) {
             return external
@@ -65,7 +69,10 @@ export function createDtsResolvePlugin({
           if (!shouldResolve) return external
         }
 
-        if (RE_TS.test(resolution) && !RE_DTS.test(resolution)) {
+        if (
+          (RE_TS.test(resolution) && !RE_DTS.test(resolution)) ||
+          RE_VUE.test(resolution)
+        ) {
           await this.load({ id: resolution })
 
           // redirect ts to dts

--- a/src/utils/filename.ts
+++ b/src/utils/filename.ts
@@ -6,12 +6,13 @@ export const RE_DTS: RegExp = /\.d\.([cm]?)ts$/
 export const RE_DTS_MAP: RegExp = /\.d\.([cm]?)ts\.map$/
 export const RE_NODE_MODULES: RegExp = /[\\/]node_modules[\\/]/
 export const RE_CSS: RegExp = /\.css$/
+export const RE_VUE: RegExp = /\.vue$/
 
 export function filename_js_to_dts(id: string): string {
   return id.replace(RE_JS, '.d.$1ts')
 }
 export function filename_ts_to_dts(id: string): string {
-  return id.replace(RE_TS, '.d.$1ts')
+  return id.replace(RE_VUE, '.vue.ts').replace(RE_TS, '.d.$1ts')
 }
 export function filename_dts_to(id: string, ext: 'js' | 'ts'): string {
   return id.replace(RE_DTS, `.$1${ext}`)

--- a/src/utils/tsc.ts
+++ b/src/utils/tsc.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import Debug from 'debug'
 import type { DtsMap } from '../generate.ts'
-import { RE_NODE_MODULES, RE_VUE } from './filename.ts'
+import { RE_NODE_MODULES } from './filename.ts'
 import { createVueProgramFactory } from './vue.ts'
 import type { TsConfigJson } from 'get-tsconfig'
 import type Ts from 'typescript'
@@ -52,6 +52,7 @@ export function createOrGetTsModule(
   id: string,
   isEntry: boolean,
   dtsMap: DtsMap,
+  vue?: boolean,
 ): TscModule {
   const program = programs.find((program) => {
     if (isEntry) {
@@ -67,7 +68,7 @@ export function createOrGetTsModule(
   }
 
   debug(`create program for module: ${id}`)
-  const module = createTsProgram(compilerOptions, dtsMap, id)
+  const module = createTsProgram(compilerOptions, dtsMap, id, vue)
   debug(`created program for module: ${id}`)
 
   programs.push(module.program)
@@ -78,6 +79,7 @@ function createTsProgram(
   compilerOptions: TsConfigJson.CompilerOptions | undefined,
   dtsMap: DtsMap,
   id: string,
+  vue?: boolean,
 ): TscModule {
   const overrideCompilerOptions: Ts.CompilerOptions =
     ts.convertCompilerOptionsFromJson(compilerOptions, '.').options
@@ -114,11 +116,9 @@ function createTsProgram(
       id,
     ]),
   ]
-  const createProgram = entries.some((id) => RE_VUE.test(id))
-    ? createVueProgramFactory()
-    : ts.createProgram
+  const createProgram = vue ? createVueProgramFactory() : ts.createProgram
   const program = createProgram({
-    rootNames: Array.from(entries),
+    rootNames: entries,
     options,
     host,
   })

--- a/src/utils/tsc.ts
+++ b/src/utils/tsc.ts
@@ -36,7 +36,6 @@ const defaultCompilerOptions: Ts.CompilerOptions = {
   checkJs: false,
   declarationMap: false,
   skipLibCheck: true,
-  preserveSymlinks: true,
   target: 99 satisfies Ts.ScriptTarget.ESNext,
   resolveJsonModule: true,
 }

--- a/src/utils/tsc.ts
+++ b/src/utils/tsc.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module'
 import Debug from 'debug'
 import type { DtsMap } from '../generate.ts'
 import { RE_NODE_MODULES, RE_VUE } from './filename.ts'
-import { createVueProgramFactory } from './vue'
+import { createVueProgramFactory } from './vue.ts'
 import type { TsConfigJson } from 'get-tsconfig'
 import type Ts from 'typescript'
 

--- a/src/utils/vue.ts
+++ b/src/utils/vue.ts
@@ -1,7 +1,7 @@
 import { proxyCreateProgram } from '@volar/typescript'
 import * as vue from '@vue/language-core'
 import Debug from 'debug'
-import { ts } from './tsc'
+import { ts } from './tsc.ts'
 import type Ts from 'typescript'
 
 const debug = Debug('rolldown-plugin-dts:vue')

--- a/src/utils/vue.ts
+++ b/src/utils/vue.ts
@@ -1,5 +1,4 @@
-import { proxyCreateProgram } from '@volar/typescript'
-import * as vue from '@vue/language-core'
+import { createRequire } from 'node:module'
 import Debug from 'debug'
 import { ts } from './tsc.ts'
 import type Ts from 'typescript'
@@ -7,12 +6,36 @@ import type Ts from 'typescript'
 const debug = Debug('rolldown-plugin-dts:vue')
 
 let createVueProgram: typeof Ts.createProgram
+const require = createRequire(import.meta.url)
+
+function loadVueLanguageTools() {
+  try {
+    const vueTscPath = require.resolve('vue-tsc')
+    const { proxyCreateProgram } = require(
+      require.resolve('@volar/typescript', {
+        paths: [vueTscPath],
+      }),
+    ) as typeof import('@volar/typescript')
+    const vue = require(
+      require.resolve('@vue/language-core', {
+        paths: [vueTscPath],
+      }),
+    ) as typeof import('@vue/language-core')
+    return { proxyCreateProgram, vue }
+  } catch (error) {
+    debug('vue language tools not found', error)
+    throw new Error(
+      'Failed to load vue language tools. Please manually install vue-tsc.',
+    )
+  }
+}
 
 // credits: https://github.com/vuejs/language-tools/blob/25f40ead59d862b3bd7011f2dd2968f47dfcf629/packages/tsc/index.ts
 export function createVueProgramFactory(): typeof Ts.createProgram {
   if (createVueProgram) return createVueProgram
 
   debug('loading vue language tools')
+  const { proxyCreateProgram, vue } = loadVueLanguageTools()
   return (createVueProgram = proxyCreateProgram(
     ts,
     ts.createProgram,

--- a/src/utils/vue.ts
+++ b/src/utils/vue.ts
@@ -1,0 +1,38 @@
+import { proxyCreateProgram } from '@volar/typescript'
+import * as vue from '@vue/language-core'
+import Debug from 'debug'
+import { ts } from './tsc'
+import type Ts from 'typescript'
+
+const debug = Debug('rolldown-plugin-dts:vue')
+
+let createVueProgram: typeof Ts.createProgram
+
+// credits: https://github.com/vuejs/language-tools/blob/25f40ead59d862b3bd7011f2dd2968f47dfcf629/packages/tsc/index.ts
+export function createVueProgramFactory(): typeof Ts.createProgram {
+  if (createVueProgram) return createVueProgram
+
+  debug('create vue program')
+  return (createVueProgram = proxyCreateProgram(
+    ts,
+    ts.createProgram,
+    (ts, options) => {
+      const { configFilePath } = options.options
+      const vueOptions =
+        typeof configFilePath === 'string'
+          ? vue.createParsedCommandLine(
+              ts,
+              ts.sys,
+              configFilePath.replaceAll('\\', '/'),
+            ).vueOptions
+          : vue.getDefaultCompilerOptions()
+      const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
+        ts,
+        options.options,
+        vueOptions,
+        (id) => id,
+      )
+      return { languagePlugins: [vueLanguagePlugin] }
+    },
+  ))
+}

--- a/src/utils/vue.ts
+++ b/src/utils/vue.ts
@@ -12,7 +12,7 @@ let createVueProgram: typeof Ts.createProgram
 export function createVueProgramFactory(): typeof Ts.createProgram {
   if (createVueProgram) return createVueProgram
 
-  debug('create vue program')
+  debug('loading vue language tools')
   return (createVueProgram = proxyCreateProgram(
     ts,
     ts.createProgram,

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -226,122 +226,85 @@ export { Unused };"
 
 exports[`vue-sfc w/ ts-compiler 1`] = `
 "// main.d.ts
-import { GlobalComponents, GlobalDirectives, ObjectDirective, ShallowRef, unref } from "vue";
-import { JSX } from "vue/jsx-runtime";
+import * as vue1 from "vue";
+import * as vue_jsx_runtime2 from "vue/jsx-runtime";
 
 //#region tests/fixtures/vue-sfc/App.vue.d.ts
 declare const _default: any;
 declare global {
-    const __VLS_intrinsicElements: __VLS_IntrinsicElements;
-    const __VLS_directiveBindingRestFields: {
-        instance: null;
-        oldValue: null;
-        modifiers: any;
-        dir: any;
+  const __VLS_intrinsicElements: __VLS_IntrinsicElements;
+  const __VLS_directiveBindingRestFields: {
+    instance: null;
+    oldValue: null;
+    modifiers: any;
+    dir: any;
+  };
+  const __VLS_unref: typeof vue1.unref;
+  const __VLS_placeholder: any;
+  type __VLS_NativeElements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
+  type __VLS_IntrinsicElements = vue_jsx_runtime2.JSX.IntrinsicElements;
+  type __VLS_Element = vue_jsx_runtime2.JSX.Element;
+  type __VLS_GlobalComponents = vue1.GlobalComponents;
+  type __VLS_GlobalDirectives = vue1.GlobalDirectives;
+  type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
+  type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
+  type __VLS_SpreadMerge<A, B> = Omit<A, keyof B> & B;
+  type __VLS_WithComponent<N0 extends string, LocalComponents, Self, N1 extends string, N2 extends string, N3 extends string> = N1 extends keyof LocalComponents ? N1 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : { [K in N0]: LocalComponents[N1] } : N2 extends keyof LocalComponents ? N2 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : { [K in N0]: LocalComponents[N2] } : N3 extends keyof LocalComponents ? N3 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : { [K in N0]: LocalComponents[N3] } : Self extends object ? { [K in N0]: Self } : N1 extends keyof __VLS_GlobalComponents ? N1 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : { [K in N0]: __VLS_GlobalComponents[N1] } : N2 extends keyof __VLS_GlobalComponents ? N2 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : { [K in N0]: __VLS_GlobalComponents[N2] } : N3 extends keyof __VLS_GlobalComponents ? N3 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : { [K in N0]: __VLS_GlobalComponents[N3] } : { [K in N0]: unknown };
+  type __VLS_FunctionalComponentProps<T, K> = '__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
+    __ctx?: {
+      props?: infer P;
     };
-    const __VLS_unref: typeof unref;
-    const __VLS_placeholder: any;
-    type __VLS_NativeElements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
-    type __VLS_IntrinsicElements = JSX.IntrinsicElements;
-    type __VLS_Element = JSX.Element;
-    type __VLS_GlobalComponents = GlobalComponents;
-    type __VLS_GlobalDirectives = GlobalDirectives;
-    type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
-    type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
-    type __VLS_SpreadMerge<A, B> = Omit<A, keyof B> & B;
-    type __VLS_WithComponent<N0 extends string, LocalComponents, Self, N1 extends string, N2 extends string, N3 extends string> = N1 extends keyof LocalComponents ? N1 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : {
-        [K in N0]: LocalComponents[N1];
-    } : N2 extends keyof LocalComponents ? N2 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : {
-        [K in N0]: LocalComponents[N2];
-    } : N3 extends keyof LocalComponents ? N3 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : {
-        [K in N0]: LocalComponents[N3];
-    } : Self extends object ? {
-        [K in N0]: Self;
-    } : N1 extends keyof __VLS_GlobalComponents ? N1 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : {
-        [K in N0]: __VLS_GlobalComponents[N1];
-    } : N2 extends keyof __VLS_GlobalComponents ? N2 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : {
-        [K in N0]: __VLS_GlobalComponents[N2];
-    } : N3 extends keyof __VLS_GlobalComponents ? N3 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : {
-        [K in N0]: __VLS_GlobalComponents[N3];
-    } : {
-        [K in N0]: unknown;
-    };
-    type __VLS_FunctionalComponentProps<T, K> = '__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
-        __ctx?: {
-            props?: infer P;
-        };
-    } ? NonNullable<P> : never : T extends (props: infer P, ...args: any) => any ? P : {};
-    type __VLS_IsFunction<T, K> = K extends keyof T ? __VLS_IsAny<T[K]> extends false ? unknown extends T[K] ? false : true : false : false;
-    type __VLS_NormalizeComponentEvent<Props, Events, onEvent extends keyof Props, Event extends keyof Events, CamelizedEvent extends keyof Events> = (__VLS_IsFunction<Props, onEvent> extends true ? Props : __VLS_IsFunction<Events, Event> extends true ? {
-        [K in onEvent]?: Events[Event];
-    } : __VLS_IsFunction<Events, CamelizedEvent> extends true ? {
-        [K in onEvent]?: Events[CamelizedEvent];
-    } : Props) & Record<string, unknown>;
-    type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends ((arg: infer P) => unknown) ? P : never;
-    type __VLS_OverloadUnionInner<T, U = unknown> = U & T extends (...args: infer A) => infer R ? U extends T ? never : __VLS_OverloadUnionInner<T, Pick<T, keyof T> & U & ((...args: A) => R)> | ((...args: A) => R) : never;
-    type __VLS_OverloadUnion<T> = Exclude<__VLS_OverloadUnionInner<(() => never) & T>, T extends () => never ? never : () => never>;
-    type __VLS_ConstructorOverloads<T> = __VLS_OverloadUnion<T> extends infer F ? F extends (event: infer E, ...args: infer A) => any ? {
-        [K in E & string]: (...args: A) => void;
-    } : never : never;
-    type __VLS_NormalizeEmits<T> = __VLS_PrettifyGlobal<__VLS_UnionToIntersection<__VLS_ConstructorOverloads<T> & {
-        [K in keyof T]: T[K] extends any[] ? {
-            (...args: T[K]): void;
-        } : never;
-    }>>;
-    type __VLS_PrettifyGlobal<T> = {
-        [K in keyof T]: T[K];
-    } & {};
-    type __VLS_PickFunctionalComponentCtx<T, K> = NonNullable<__VLS_PickNotAny<'__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
-        __ctx?: infer Ctx;
-    } ? Ctx : never : any, T extends (props: any, ctx: infer Ctx) => any ? Ctx : any>>;
-    type __VLS_OmitStringIndex<T> = {
-        [K in keyof T as string extends K ? never : K]: T[K];
-    };
-    type __VLS_UseTemplateRef<T> = Readonly<ShallowRef<T | null>>;
-    function __VLS_getVForSourceType<T extends number | string | any[] | Iterable<any>>(source: T): [
-        item: T extends number ? number : T extends string ? string : T extends any[] ? T[number] : T extends Iterable<infer T1> ? T1 : any,
-        index: number
-    ][];
-    function __VLS_getVForSourceType<T>(source: T): [
-        item: T[keyof T],
-        key: keyof T,
-        index: number
-    ][];
-    function __VLS_getSlotParams<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>;
-    function __VLS_getSlotParam<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>[0];
-    function __VLS_asFunctionalDirective<T>(dir: T): T extends ObjectDirective ? NonNullable<T['created' | 'beforeMount' | 'mounted' | 'beforeUpdate' | 'updated' | 'beforeUnmount' | 'unmounted']> : T extends (...args: any) => any ? T : (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown) => void;
-    function __VLS_makeOptional<T>(t: T): {
-        [K in keyof T]?: T[K];
-    };
-    function __VLS_asFunctionalComponent<T, K = T extends new (...args: any) => any ? InstanceType<T> : unknown>(t: T, instance?: K): T extends new (...args: any) => any ? (props: (K extends {
+  } ? NonNullable<P> : never : T extends ((props: infer P, ...args: any) => any) ? P : {};
+  type __VLS_IsFunction<T, K> = K extends keyof T ? __VLS_IsAny<T[K]> extends false ? unknown extends T[K] ? false : true : false : false;
+  type __VLS_NormalizeComponentEvent<Props, Events, onEvent extends keyof Props, Event extends keyof Events, CamelizedEvent extends keyof Events> = (__VLS_IsFunction<Props, onEvent> extends true ? Props : __VLS_IsFunction<Events, Event> extends true ? { [K in onEvent]?: Events[Event] } : __VLS_IsFunction<Events, CamelizedEvent> extends true ? { [K in onEvent]?: Events[CamelizedEvent] } : Props) & Record<string, unknown>;
+  type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends ((arg: infer P) => unknown) ? P : never;
+  type __VLS_OverloadUnionInner<T, U = unknown> = U & T extends ((...args: infer A) => infer R) ? U extends T ? never : __VLS_OverloadUnionInner<T, Pick<T, keyof T> & U & ((...args: A) => R)> | ((...args: A) => R) : never;
+  type __VLS_OverloadUnion<T> = Exclude<__VLS_OverloadUnionInner<(() => never) & T>, T extends (() => never) ? never : () => never>;
+  type __VLS_ConstructorOverloads<T> = __VLS_OverloadUnion<T> extends infer F ? F extends ((event: infer E, ...args: infer A) => any) ? { [K in E & string]: (...args: A) => void } : never : never;
+  type __VLS_NormalizeEmits<T> = __VLS_PrettifyGlobal<__VLS_UnionToIntersection<__VLS_ConstructorOverloads<T> & { [K in keyof T]: T[K] extends any[] ? {
+    (...args: T[K]): void;
+  } : never }>>;
+  type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K] } & {};
+  type __VLS_PickFunctionalComponentCtx<T, K> = NonNullable<__VLS_PickNotAny<'__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
+    __ctx?: infer Ctx;
+  } ? Ctx : never : any, T extends ((props: any, ctx: infer Ctx) => any) ? Ctx : any>>;
+  type __VLS_OmitStringIndex<T> = { [K in keyof T as string extends K ? never : K]: T[K] };
+  type __VLS_UseTemplateRef<T> = Readonly<vue1.ShallowRef<T | null>>;
+  function __VLS_getVForSourceType<T extends number | string | any[] | Iterable<any>>(source: T): [item: T extends number ? number : T extends string ? string : T extends any[] ? T[number] : T extends Iterable<infer T1> ? T1 : any, index: number][];
+  function __VLS_getVForSourceType<T>(source: T): [item: T[keyof T], key: keyof T, index: number][];
+  function __VLS_getSlotParams<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>;
+  function __VLS_getSlotParam<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>[0];
+  function __VLS_asFunctionalDirective<T>(dir: T): T extends vue1.ObjectDirective ? NonNullable<T['created' | 'beforeMount' | 'mounted' | 'beforeUpdate' | 'updated' | 'beforeUnmount' | 'unmounted']> : T extends ((...args: any) => any) ? T : (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown) => void;
+  function __VLS_makeOptional<T>(t: T): { [K in keyof T]?: T[K] };
+  function __VLS_asFunctionalComponent<T, K = (T extends (new (...args: any) => any) ? InstanceType<T> : unknown)>(t: T, instance?: K): T extends (new (...args: any) => any) ? (props: (K extends {
+    $props: infer Props;
+  } ? Props : any) & Record<string, unknown>, ctx?: any) => __VLS_Element & {
+    __ctx?: {
+      attrs?: any;
+      slots?: K extends {
+        $slots: infer Slots;
+      } ? Slots : any;
+      emit?: K extends {
+        $emit: infer Emit;
+      } ? Emit : any;
+      expose?(exposed: K): void;
+      props?: (K extends {
         $props: infer Props;
-    } ? Props : any) & Record<string, unknown>, ctx?: any) => __VLS_Element & {
-        __ctx?: {
-            attrs?: any;
-            slots?: K extends {
-                $slots: infer Slots;
-            } ? Slots : any;
-            emit?: K extends {
-                $emit: infer Emit;
-            } ? Emit : any;
-            expose?(exposed: K): void;
-            props?: (K extends {
-                $props: infer Props;
-            } ? Props : any) & Record<string, unknown>;
-        };
-    } : T extends () => any ? (props: {}, ctx?: any) => ReturnType<T> : T extends (...args: any) => any ? T : (_: {} & Record<string, unknown>, ctx?: any) => {
-        __ctx?: {
-            attrs?: any;
-            expose?: any;
-            slots?: any;
-            emit?: any;
-            props?: {} & Record<string, unknown>;
-        };
+      } ? Props : any) & Record<string, unknown>;
     };
-    function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): 2 extends Parameters<T>['length'] ? [any] : [];
-    function __VLS_asFunctionalElement<T>(tag: T, endTag?: T): (attrs: T & Record<string, unknown>) => void;
-    function __VLS_asFunctionalSlot<S>(slot: S): (props: NonNullable<S> extends (props: infer P) => any ? P : {}) => void;
-    function __VLS_tryAsConstant<const T>(t: T): T;
+  } : T extends (() => any) ? (props: {}, ctx?: any) => ReturnType<T> : T extends ((...args: any) => any) ? T : (_: {} & Record<string, unknown>, ctx?: any) => {
+    __ctx?: {
+      attrs?: any;
+      expose?: any;
+      slots?: any;
+      emit?: any;
+      props?: {} & Record<string, unknown>;
+    };
+  };
+  function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): 2 extends Parameters<T>['length'] ? [any] : [];
+  function __VLS_asFunctionalElement<T>(tag: T, endTag?: T): (attrs: T & Record<string, unknown>) => void;
+  function __VLS_asFunctionalSlot<S>(slot: S): (props: NonNullable<S> extends ((props: infer P) => any) ? P : {}) => void;
+  function __VLS_tryAsConstant<const T>(t: T): T;
 }
 
 //#endregion

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -223,3 +223,127 @@ interface Unused {
 //#endregion
 export { Unused };"
 `;
+
+exports[`vue-sfc w/ ts-compiler 1`] = `
+"// main.d.ts
+import { GlobalComponents, GlobalDirectives, ObjectDirective, ShallowRef, unref } from "vue";
+import { JSX } from "vue/jsx-runtime";
+
+//#region tests/fixtures/vue-sfc/App.vue.d.ts
+declare const _default: any;
+declare global {
+    const __VLS_intrinsicElements: __VLS_IntrinsicElements;
+    const __VLS_directiveBindingRestFields: {
+        instance: null;
+        oldValue: null;
+        modifiers: any;
+        dir: any;
+    };
+    const __VLS_unref: typeof unref;
+    const __VLS_placeholder: any;
+    type __VLS_NativeElements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
+    type __VLS_IntrinsicElements = JSX.IntrinsicElements;
+    type __VLS_Element = JSX.Element;
+    type __VLS_GlobalComponents = GlobalComponents;
+    type __VLS_GlobalDirectives = GlobalDirectives;
+    type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
+    type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
+    type __VLS_SpreadMerge<A, B> = Omit<A, keyof B> & B;
+    type __VLS_WithComponent<N0 extends string, LocalComponents, Self, N1 extends string, N2 extends string, N3 extends string> = N1 extends keyof LocalComponents ? N1 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : {
+        [K in N0]: LocalComponents[N1];
+    } : N2 extends keyof LocalComponents ? N2 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : {
+        [K in N0]: LocalComponents[N2];
+    } : N3 extends keyof LocalComponents ? N3 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : {
+        [K in N0]: LocalComponents[N3];
+    } : Self extends object ? {
+        [K in N0]: Self;
+    } : N1 extends keyof __VLS_GlobalComponents ? N1 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : {
+        [K in N0]: __VLS_GlobalComponents[N1];
+    } : N2 extends keyof __VLS_GlobalComponents ? N2 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : {
+        [K in N0]: __VLS_GlobalComponents[N2];
+    } : N3 extends keyof __VLS_GlobalComponents ? N3 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : {
+        [K in N0]: __VLS_GlobalComponents[N3];
+    } : {
+        [K in N0]: unknown;
+    };
+    type __VLS_FunctionalComponentProps<T, K> = '__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
+        __ctx?: {
+            props?: infer P;
+        };
+    } ? NonNullable<P> : never : T extends (props: infer P, ...args: any) => any ? P : {};
+    type __VLS_IsFunction<T, K> = K extends keyof T ? __VLS_IsAny<T[K]> extends false ? unknown extends T[K] ? false : true : false : false;
+    type __VLS_NormalizeComponentEvent<Props, Events, onEvent extends keyof Props, Event extends keyof Events, CamelizedEvent extends keyof Events> = (__VLS_IsFunction<Props, onEvent> extends true ? Props : __VLS_IsFunction<Events, Event> extends true ? {
+        [K in onEvent]?: Events[Event];
+    } : __VLS_IsFunction<Events, CamelizedEvent> extends true ? {
+        [K in onEvent]?: Events[CamelizedEvent];
+    } : Props) & Record<string, unknown>;
+    type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends ((arg: infer P) => unknown) ? P : never;
+    type __VLS_OverloadUnionInner<T, U = unknown> = U & T extends (...args: infer A) => infer R ? U extends T ? never : __VLS_OverloadUnionInner<T, Pick<T, keyof T> & U & ((...args: A) => R)> | ((...args: A) => R) : never;
+    type __VLS_OverloadUnion<T> = Exclude<__VLS_OverloadUnionInner<(() => never) & T>, T extends () => never ? never : () => never>;
+    type __VLS_ConstructorOverloads<T> = __VLS_OverloadUnion<T> extends infer F ? F extends (event: infer E, ...args: infer A) => any ? {
+        [K in E & string]: (...args: A) => void;
+    } : never : never;
+    type __VLS_NormalizeEmits<T> = __VLS_PrettifyGlobal<__VLS_UnionToIntersection<__VLS_ConstructorOverloads<T> & {
+        [K in keyof T]: T[K] extends any[] ? {
+            (...args: T[K]): void;
+        } : never;
+    }>>;
+    type __VLS_PrettifyGlobal<T> = {
+        [K in keyof T]: T[K];
+    } & {};
+    type __VLS_PickFunctionalComponentCtx<T, K> = NonNullable<__VLS_PickNotAny<'__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
+        __ctx?: infer Ctx;
+    } ? Ctx : never : any, T extends (props: any, ctx: infer Ctx) => any ? Ctx : any>>;
+    type __VLS_OmitStringIndex<T> = {
+        [K in keyof T as string extends K ? never : K]: T[K];
+    };
+    type __VLS_UseTemplateRef<T> = Readonly<ShallowRef<T | null>>;
+    function __VLS_getVForSourceType<T extends number | string | any[] | Iterable<any>>(source: T): [
+        item: T extends number ? number : T extends string ? string : T extends any[] ? T[number] : T extends Iterable<infer T1> ? T1 : any,
+        index: number
+    ][];
+    function __VLS_getVForSourceType<T>(source: T): [
+        item: T[keyof T],
+        key: keyof T,
+        index: number
+    ][];
+    function __VLS_getSlotParams<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>;
+    function __VLS_getSlotParam<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>[0];
+    function __VLS_asFunctionalDirective<T>(dir: T): T extends ObjectDirective ? NonNullable<T['created' | 'beforeMount' | 'mounted' | 'beforeUpdate' | 'updated' | 'beforeUnmount' | 'unmounted']> : T extends (...args: any) => any ? T : (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown) => void;
+    function __VLS_makeOptional<T>(t: T): {
+        [K in keyof T]?: T[K];
+    };
+    function __VLS_asFunctionalComponent<T, K = T extends new (...args: any) => any ? InstanceType<T> : unknown>(t: T, instance?: K): T extends new (...args: any) => any ? (props: (K extends {
+        $props: infer Props;
+    } ? Props : any) & Record<string, unknown>, ctx?: any) => __VLS_Element & {
+        __ctx?: {
+            attrs?: any;
+            slots?: K extends {
+                $slots: infer Slots;
+            } ? Slots : any;
+            emit?: K extends {
+                $emit: infer Emit;
+            } ? Emit : any;
+            expose?(exposed: K): void;
+            props?: (K extends {
+                $props: infer Props;
+            } ? Props : any) & Record<string, unknown>;
+        };
+    } : T extends () => any ? (props: {}, ctx?: any) => ReturnType<T> : T extends (...args: any) => any ? T : (_: {} & Record<string, unknown>, ctx?: any) => {
+        __ctx?: {
+            attrs?: any;
+            expose?: any;
+            slots?: any;
+            emit?: any;
+            props?: {} & Record<string, unknown>;
+        };
+    };
+    function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): 2 extends Parameters<T>['length'] ? [any] : [];
+    function __VLS_asFunctionalElement<T>(tag: T, endTag?: T): (attrs: T & Record<string, unknown>) => void;
+    function __VLS_asFunctionalSlot<S>(slot: S): (props: NonNullable<S> extends (props: infer P) => any ? P : {}) => void;
+    function __VLS_tryAsConstant<const T>(t: T): T;
+}
+
+//#endregion
+export { _default as App };"
+`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -226,87 +226,12 @@ export { Unused };"
 
 exports[`vue-sfc w/ ts-compiler 1`] = `
 "// main.d.ts
-import * as vue1 from "vue";
-import * as vue_jsx_runtime2 from "vue/jsx-runtime";
-
 //#region tests/fixtures/vue-sfc/App.vue.d.ts
-declare const _default: any;
 declare global {
-  const __VLS_intrinsicElements: __VLS_IntrinsicElements;
-  const __VLS_directiveBindingRestFields: {
-    instance: null;
-    oldValue: null;
-    modifiers: any;
-    dir: any;
-  };
-  const __VLS_unref: typeof vue1.unref;
-  const __VLS_placeholder: any;
-  type __VLS_NativeElements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
-  type __VLS_IntrinsicElements = vue_jsx_runtime2.JSX.IntrinsicElements;
-  type __VLS_Element = vue_jsx_runtime2.JSX.Element;
-  type __VLS_GlobalComponents = vue1.GlobalComponents;
-  type __VLS_GlobalDirectives = vue1.GlobalDirectives;
-  type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
-  type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
-  type __VLS_SpreadMerge<A, B> = Omit<A, keyof B> & B;
-  type __VLS_WithComponent<N0 extends string, LocalComponents, Self, N1 extends string, N2 extends string, N3 extends string> = N1 extends keyof LocalComponents ? N1 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : { [K in N0]: LocalComponents[N1] } : N2 extends keyof LocalComponents ? N2 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : { [K in N0]: LocalComponents[N2] } : N3 extends keyof LocalComponents ? N3 extends N0 ? Pick<LocalComponents, N0 extends keyof LocalComponents ? N0 : never> : { [K in N0]: LocalComponents[N3] } : Self extends object ? { [K in N0]: Self } : N1 extends keyof __VLS_GlobalComponents ? N1 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : { [K in N0]: __VLS_GlobalComponents[N1] } : N2 extends keyof __VLS_GlobalComponents ? N2 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : { [K in N0]: __VLS_GlobalComponents[N2] } : N3 extends keyof __VLS_GlobalComponents ? N3 extends N0 ? Pick<__VLS_GlobalComponents, N0 extends keyof __VLS_GlobalComponents ? N0 : never> : { [K in N0]: __VLS_GlobalComponents[N3] } : { [K in N0]: unknown };
-  type __VLS_FunctionalComponentProps<T, K> = '__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
-    __ctx?: {
-      props?: infer P;
-    };
-  } ? NonNullable<P> : never : T extends ((props: infer P, ...args: any) => any) ? P : {};
-  type __VLS_IsFunction<T, K> = K extends keyof T ? __VLS_IsAny<T[K]> extends false ? unknown extends T[K] ? false : true : false : false;
-  type __VLS_NormalizeComponentEvent<Props, Events, onEvent extends keyof Props, Event extends keyof Events, CamelizedEvent extends keyof Events> = (__VLS_IsFunction<Props, onEvent> extends true ? Props : __VLS_IsFunction<Events, Event> extends true ? { [K in onEvent]?: Events[Event] } : __VLS_IsFunction<Events, CamelizedEvent> extends true ? { [K in onEvent]?: Events[CamelizedEvent] } : Props) & Record<string, unknown>;
-  type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends ((arg: infer P) => unknown) ? P : never;
-  type __VLS_OverloadUnionInner<T, U = unknown> = U & T extends ((...args: infer A) => infer R) ? U extends T ? never : __VLS_OverloadUnionInner<T, Pick<T, keyof T> & U & ((...args: A) => R)> | ((...args: A) => R) : never;
-  type __VLS_OverloadUnion<T> = Exclude<__VLS_OverloadUnionInner<(() => never) & T>, T extends (() => never) ? never : () => never>;
-  type __VLS_ConstructorOverloads<T> = __VLS_OverloadUnion<T> extends infer F ? F extends ((event: infer E, ...args: infer A) => any) ? { [K in E & string]: (...args: A) => void } : never : never;
-  type __VLS_NormalizeEmits<T> = __VLS_PrettifyGlobal<__VLS_UnionToIntersection<__VLS_ConstructorOverloads<T> & { [K in keyof T]: T[K] extends any[] ? {
-    (...args: T[K]): void;
-  } : never }>>;
-  type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K] } & {};
-  type __VLS_PickFunctionalComponentCtx<T, K> = NonNullable<__VLS_PickNotAny<'__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends {
-    __ctx?: infer Ctx;
-  } ? Ctx : never : any, T extends ((props: any, ctx: infer Ctx) => any) ? Ctx : any>>;
-  type __VLS_OmitStringIndex<T> = { [K in keyof T as string extends K ? never : K]: T[K] };
-  type __VLS_UseTemplateRef<T> = Readonly<vue1.ShallowRef<T | null>>;
-  function __VLS_getVForSourceType<T extends number | string | any[] | Iterable<any>>(source: T): [item: T extends number ? number : T extends string ? string : T extends any[] ? T[number] : T extends Iterable<infer T1> ? T1 : any, index: number][];
-  function __VLS_getVForSourceType<T>(source: T): [item: T[keyof T], key: keyof T, index: number][];
-  function __VLS_getSlotParams<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>;
-  function __VLS_getSlotParam<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>[0];
-  function __VLS_asFunctionalDirective<T>(dir: T): T extends vue1.ObjectDirective ? NonNullable<T['created' | 'beforeMount' | 'mounted' | 'beforeUpdate' | 'updated' | 'beforeUnmount' | 'unmounted']> : T extends ((...args: any) => any) ? T : (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown) => void;
-  function __VLS_makeOptional<T>(t: T): { [K in keyof T]?: T[K] };
-  function __VLS_asFunctionalComponent<T, K = (T extends (new (...args: any) => any) ? InstanceType<T> : unknown)>(t: T, instance?: K): T extends (new (...args: any) => any) ? (props: (K extends {
-    $props: infer Props;
-  } ? Props : any) & Record<string, unknown>, ctx?: any) => __VLS_Element & {
-    __ctx?: {
-      attrs?: any;
-      slots?: K extends {
-        $slots: infer Slots;
-      } ? Slots : any;
-      emit?: K extends {
-        $emit: infer Emit;
-      } ? Emit : any;
-      expose?(exposed: K): void;
-      props?: (K extends {
-        $props: infer Props;
-      } ? Props : any) & Record<string, unknown>;
-    };
-  } : T extends (() => any) ? (props: {}, ctx?: any) => ReturnType<T> : T extends ((...args: any) => any) ? T : (_: {} & Record<string, unknown>, ctx?: any) => {
-    __ctx?: {
-      attrs?: any;
-      expose?: any;
-      slots?: any;
-      emit?: any;
-      props?: {} & Record<string, unknown>;
-    };
-  };
-  function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): 2 extends Parameters<T>['length'] ? [any] : [];
-  function __VLS_asFunctionalElement<T>(tag: T, endTag?: T): (attrs: T & Record<string, unknown>) => void;
-  function __VLS_asFunctionalSlot<S>(slot: S): (props: NonNullable<S> extends ((props: infer P) => any) ? P : {}) => void;
-  function __VLS_tryAsConstant<const T>(t: T): T;
+  interface Window {
+    foo: string;
+  }
 }
-
-//#endregion
+declare const _default: any; //#endregion
 export { _default as App };"
 `;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -232,6 +232,20 @@ declare global {
     foo: string;
   }
 }
-declare const _default: any; //#endregion
+declare const __VLS_ctx: InstanceType<__VLS_PickNotAny<typeof __VLS_self, new () => {}>>;
+declare var __VLS_1: {};
+type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.$slots> & {
+  default?: (props: typeof __VLS_1) => any;
+}>;
+declare const __VLS_self: any;
+declare const __VLS_component: any;
+declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;
+type __VLS_WithSlots<T, S> = T & {
+  new (): {
+    $slots: S;
+  };
+};
+
+//#endregion
 export { _default as App };"
 `;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -226,25 +226,18 @@ export { Unused };"
 
 exports[`vue-sfc w/ ts-compiler 1`] = `
 "// main.d.ts
+import * as vue1 from "vue";
+
 //#region tests/fixtures/vue-sfc/App.vue.d.ts
+type __VLS_Props = {
+  foo: string;
+};
 declare global {
   interface Window {
     foo: string;
   }
 }
-declare const __VLS_ctx: InstanceType<__VLS_PickNotAny<typeof __VLS_self, new () => {}>>;
-declare var __VLS_1: {};
-type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.$slots> & {
-  default?: (props: typeof __VLS_1) => any;
-}>;
-declare const __VLS_self: any;
-declare const __VLS_component: any;
-declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;
-type __VLS_WithSlots<T, S> = T & {
-  new (): {
-    $slots: S;
-  };
-};
+declare const _default: vue1.DefineComponent<__VLS_Props, {}, {}, {}, {}, vue1.ComponentOptionsMixin, vue1.ComponentOptionsMixin, {}, string, vue1.PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, vue1.ComponentProvideOptions, false, {}, any>;
 
 //#endregion
 export { _default as App };"

--- a/tests/fixtures/vue-sfc/App.vue
+++ b/tests/fixtures/vue-sfc/App.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 defineProps<{ foo: string }>()
+
+declare global {
+  interface Window {
+    foo: string
+  }
+}
 </script>
 
 <template>

--- a/tests/fixtures/vue-sfc/App.vue
+++ b/tests/fixtures/vue-sfc/App.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ foo: string }>()
+</script>
+
+<template>
+  <div>Vue SFC</div>
+</template>

--- a/tests/fixtures/vue-sfc/App.vue
+++ b/tests/fixtures/vue-sfc/App.vue
@@ -10,5 +10,4 @@ declare global {
 
 <template>
   <div>Vue SFC</div>
-  <slot />
 </template>

--- a/tests/fixtures/vue-sfc/App.vue
+++ b/tests/fixtures/vue-sfc/App.vue
@@ -10,4 +10,5 @@ declare global {
 
 <template>
   <div>Vue SFC</div>
+  <slot />
 </template>

--- a/tests/fixtures/vue-sfc/main.ts
+++ b/tests/fixtures/vue-sfc/main.ts
@@ -1,0 +1,3 @@
+import App from './App.vue'
+
+export { App }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -167,11 +167,7 @@ test('vue-sfc w/ ts-compiler', async () => {
   const { snapshot } = await rolldownBuild(path.resolve(root, 'main.ts'), [
     dts({
       emitDtsOnly: true,
-      compilerOptions: {
-        skipLibCheck: true,
-        isolatedDeclarations: false,
-      },
-      isolatedDeclarations: false,
+      vue: true,
     }),
   ])
   expect(snapshot).toMatchSnapshot()

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -161,3 +161,18 @@ test('dts input', async () => {
   })
   expect(snapshot).toMatchSnapshot()
 })
+
+test('vue-sfc w/ ts-compiler', async () => {
+  const root = path.resolve(dirname, 'fixtures/vue-sfc')
+  const { snapshot } = await rolldownBuild(path.resolve(root, 'main.ts'), [
+    dts({
+      emitDtsOnly: true,
+      compilerOptions: {
+        skipLibCheck: true,
+        isolatedDeclarations: false,
+      },
+      isolatedDeclarations: false,
+    }),
+  ])
+  expect(snapshot).toMatchSnapshot()
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

closes #17 

Issues here:

#### 1. Importee 
We should replace `./App.vue` importee to `./App` for better type inferences, the `vite-plugin-dts` has rewritten this in the `transform` stage by using Babel. How should we support this with better performance?

#### 2.  Emitting DTS Content

Interestingly, Volar has some issues when emitting a single file. The history here:

https://github.com/vuejs/language-tools/issues/5232#issuecomment-2693434134

To solve this, `vite-plugin-dts` has [removed the whole `VLS` node](https://github.com/qmhc/vite-plugin-dts/blob/a1a26a576cd4607f6f3cd9af45f4681b5473b0b3/src/transform.ts#L242-L246) when transforming.

I will investigate the vue-language-core later.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
