### PR TITLE
fix: keep var side‑effects for declare in fake JS

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -175,7 +175,7 @@ export function createFakeJsPlugin({
         t.numericLiteral(0),
         ...deps.map((dep) => t.arrowFunctionExpression([], dep)),
         ...(sideEffect
-          ? [t.callExpression(t.identifier('sideEffect'), [])]
+          ? [t.callExpression(t.identifier('sideEffect'), [bindings[0]])]
           : []),
       ]
       const runtime: t.ArrayExpression = t.arrayExpression(elements)


### PR DESCRIPTION
closes #66
