### PR TITLE
fix: removed source map comment from generated .d.ts code

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -270,6 +270,7 @@ export function createGeneratePlugin({
           dtsCode = result.code
           map = result.map
         }
+        dtsCode = dtsCode?.replace(/(?:^|\n)\/\/[@#][\t ]*sourceMappingURL=\S*\s*$/g, '');
 
         return {
           code: dtsCode || '',

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -270,7 +270,8 @@ export function createGeneratePlugin({
           dtsCode = result.code
           map = result.map
         }
-        dtsCode = dtsCode?.replace(/(?:^|\n)\/\/[@#][\t ]*sourceMappingURL=\S*\s*$/g, '');
+        const sourceMapRE = /(?:^|\n)\/\/[@#][\t ]*sourceMappingURL=\S*\s*$/g
+        dtsCode = dtsCode?.replace(sourceMapRE, '')
 
         return {
           code: dtsCode || '',


### PR DESCRIPTION
### Description
Removed superfluous source map URL comment from `.d.ts` code generated by tsc. This fixes having two of them in the final declaration file chunk after rolldown adds it's own.

### Linked Issues
fixes #71 

### Additional context
The failing tests are from the main branch, not me.
