### PR TITLE
fix: propagate tsc errors

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -262,6 +262,11 @@ export function createGeneratePlugin({
             vue,
             context: tscContext,
           }
+
+          options.tsconfigRaw.compilerOptions ??= {}
+          options.tsconfigRaw.compilerOptions.module = 'preserve'
+          options.tsconfigRaw.compilerOptions.moduleResolution = 'bundler'
+
           let result: TscResult
           if (parallel) {
             result = await rpc!.tscEmit(options)

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -262,7 +262,6 @@ export function createGeneratePlugin({
             vue,
             context: tscContext,
           }
-
           let result: TscResult
           if (parallel) {
             result = await rpc!.tscEmit(options)

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -263,10 +263,6 @@ export function createGeneratePlugin({
             context: tscContext,
           }
 
-          options.tsconfigRaw.compilerOptions ??= {}
-          options.tsconfigRaw.compilerOptions.module = 'preserve'
-          options.tsconfigRaw.compilerOptions.moduleResolution = 'bundler'
-
           let result: TscResult
           if (parallel) {
             result = await rpc!.tscEmit(options)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -84,7 +84,9 @@ export function createDtsResolvePlugin({
             const isRelativeOrAbsolute =
               id.startsWith('.') || path.isAbsolute(id)
             if (isRelativeOrAbsolute) {
-              return this.error(`Cannot resolve import '${id}' from '${importer}'`)
+              return this.error(
+                `Cannot resolve import '${id}' from '${importer}'`,
+              )
             }
             return external
           }

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -298,7 +298,6 @@ export function tscEmit(tscOptions: TscOptions): TscResult {
   const module = createOrGetTsModule(tscOptions)
   const { program, file } = module
   debug(`got source file: ${file.fileName}`)
-
   let dtsCode: string | undefined
   let map: SourceMapInput | undefined
 

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -298,6 +298,15 @@ export function tscEmit(tscOptions: TscOptions): TscResult {
   const module = createOrGetTsModule(tscOptions)
   const { program, file } = module
   debug(`got source file: ${file.fileName}`)
+
+  const preEmitDiagnostics = ts.getPreEmitDiagnostics(program)
+  const errors = preEmitDiagnostics.filter(
+    (d: ts.Diagnostic) => d.category === ts.DiagnosticCategory.Error,
+  )
+  if (errors.length > 0) {
+    return { error: ts.formatDiagnostics(errors, formatHost) }
+  }
+
   let dtsCode: string | undefined
   let map: SourceMapInput | undefined
 

--- a/tests/fixtures/type-error.ts
+++ b/tests/fixtures/type-error.ts
@@ -1,0 +1,3 @@
+export const n: number = 'string'
+
+

--- a/tests/fixtures/type-error.ts
+++ b/tests/fixtures/type-error.ts
@@ -1,3 +1,1 @@
 export const n: number = 'string'
-
-

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -17,6 +17,8 @@ describe('tsc', () => {
         dts({
           emitDtsOnly: true,
           compilerOptions: {
+            module: 'preserve',
+            moduleResolution: 'bundler',
             skipLibCheck: true,
             isolatedDeclarations: false,
           },
@@ -33,7 +35,11 @@ describe('tsc', () => {
       [
         dts({
           emitDtsOnly: true,
-          compilerOptions: { isolatedDeclarations: false },
+          compilerOptions: {
+            module: 'preserve',
+            moduleResolution: 'bundler',
+            isolatedDeclarations: false,
+          },
         }),
       ],
     )

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -132,6 +132,9 @@ describe('tsc', () => {
       dts({
         emitDtsOnly: true,
         vue: true,
+        compilerOptions: {
+          isolatedDeclarations: false,
+        },
       }),
     ])
     expect(snapshot).toMatchSnapshot()

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -175,11 +175,7 @@ describe('tsc', () => {
     await expect(() =>
       rolldownBuild(path.resolve(dirname, 'fixtures/type-error.ts'), [
         dts({
-          emitDtsOnly: true,
           oxc: false,
-          compilerOptions: {
-            isolatedDeclarations: false,
-          },
         }),
       ]),
     ).rejects.toThrow('error TS2322')

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -170,4 +170,18 @@ describe('tsc', () => {
     ])
     expect(snapshot).toMatchSnapshot()
   })
+
+  test('fail on type errors', async () => {
+    await expect(() =>
+      rolldownBuild(path.resolve(dirname, 'fixtures/type-error.ts'), [
+        dts({
+          emitDtsOnly: true,
+          oxc: false,
+          compilerOptions: {
+            isolatedDeclarations: false,
+          },
+        }),
+      ]),
+    ).rejects.toThrow('error TS2322')
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Previously, tsc errors were ignored. Since tsc usually emits files even with type errors, it was possible for .d.ts files that don't pass type-checking to be generated.

This PR ensures that type errors are caught as a build error.

This surfaced errors in existing tests (which is great!), so I updated the tsc call to use the following compilerOptions for dts generation:
- `moduleResolution: "bundler"` – most lenient and compatible mode (for bundlers)
- `module: "preserve"` – required for `bundler` mode (`es2015`+ also works)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
