### PR TITLE
fix: error on missing file import

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -73,11 +73,19 @@ export function createDtsResolvePlugin({
           !dtsResolution ||
           (!RE_TS.test(dtsResolution) && !RE_VUE.test(dtsResolution))
         ) {
-          if (
+          const unresolved =
             !rolldownResolution ||
             (!RE_TS.test(rolldownResolution.id) &&
               !RE_VUE.test(rolldownResolution.id))
-          ) {
+
+          if (unresolved) {
+            // For relative/absolute type imports, surface an error instead of
+            // silently externalizing so users know a local type file is missing.
+            const isRelativeOrAbsolute =
+              id.startsWith('.') || path.isAbsolute(id)
+            if (isRelativeOrAbsolute) {
+              return this.error(`Cannot resolve import '${id}' from '${importer}'`)
+            }
             return external
           }
           dtsResolution = rolldownResolution.id

--- a/tests/fixtures/unresolved-import/index.d.ts
+++ b/tests/fixtures/unresolved-import/index.d.ts
@@ -1,0 +1,1 @@
+export * from './missing-file'

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -164,3 +164,16 @@ test('cjs exports', async () => {
     expect(snapshot).toMatchSnapshot()
   }
 })
+
+test('should error when file import cannot be found', async () => {
+  await expect(() =>
+    rolldownBuild(
+      path.resolve(dirname, 'fixtures/unresolved-import/index.d.ts'),
+      [
+        dts({
+          emitDtsOnly: true,
+        }),
+      ],
+    ),
+  ).rejects.toThrow("Cannot resolve import './missing-file'")
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Previously, when a file import couldn't be resolved (e.g. `import './file'`), it would automatically get externalized.

Now it errors.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
