### PR TITLE
fix: split `tsc` and `tsc --build` workflows

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -63,6 +63,7 @@ export function createGeneratePlugin({
   tsgo,
   newContext,
   emitJs,
+  sourcemap,
 }: Pick<
   OptionsResolved,
   | 'cwd'
@@ -78,6 +79,7 @@ export function createGeneratePlugin({
   | 'tsgo'
   | 'newContext'
   | 'emitJs'
+  | 'sourcemap'
 >): Plugin {
   const dtsMap: DtsMap = new Map<string, TsModule>()
 
@@ -265,6 +267,7 @@ export function createGeneratePlugin({
             cwd,
             entries,
             id,
+            sourcemap,
             vue,
             context: tscContext,
           }

--- a/src/tsc/context.ts
+++ b/src/tsc/context.ts
@@ -3,15 +3,29 @@ import type ts from 'typescript'
 
 const debug = Debug('rolldown-plugin-dts:tsc-context')
 
+// A parsed tsconfig file with its path.
+export interface ParsedProject {
+  tsconfigPath: string
+  parsedConfig: ts.ParsedCommandLine
+}
+
+// A map of a source file to the project it belongs to. This makes it faster to
+// find the project for a source file.
+export type SourceFileToProjectMap = Map<string, ParsedProject>
+
 export interface TscContext {
   programs: ts.Program[]
   files: Map<string, string>
+
+  // A map of a root tsconfig to all projects referenced from it.
+  projects: Map<string, SourceFileToProjectMap>
 }
 
 export function createContext(): TscContext {
   const programs: ts.Program[] = []
   const files = new Map<string, string>()
-  return { programs, files }
+  const projects = new Map<string, SourceFileToProjectMap>()
+  return { programs, files, projects }
 }
 
 export function invalidateContextFile(context: TscContext, file: string): void {
@@ -22,6 +36,7 @@ export function invalidateContextFile(context: TscContext, file: string): void {
       .getSourceFiles()
       .some((sourceFile) => sourceFile.fileName === file)
   })
+  context.projects.clear()
 }
 
 export const globalContext: TscContext = createContext()

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -321,13 +321,12 @@ function tscEmitBuild(tscOptions: TscOptions): TscResult {
 
     if (outputFile.endsWith('.d.ts.map')) {
       if (!fsSystem.fileExists(outputFile)) {
-        console.warn(`[rolldown-plugin-dts] Unable to read file ${outputFile}`)
         continue
       }
 
       const text = fsSystem.readFile(outputFile)
       if (!text) {
-        console.warn(`[rolldown-plugin-dts] Unexpected empty ${outputFile}`)
+        console.warn(`[rolldown-plugin-dts] Unexpected sourcemap ${outputFile}`)
         continue
       }
 

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -306,8 +306,6 @@ function tscEmitBuild(tscOptions: TscOptions): TscResult {
     ignoreCase,
   )
 
-  debug('outputFiles %O', outputFiles)
-
   let code: string | undefined
   let map: ExistingRawSourceMap | undefined
 

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -180,7 +180,7 @@ function createTsProgramFromParsedConfig({
 
     if (hasReferences) {
       throw new Error(
-        `[rolldown-plugin-dts] Unable to load ${id}. You have "references" in your tsconfig file. Maybe you want to add \`dts: { build: true }\` in your config?`,
+        `[rolldown-plugin-dts] Unable to load ${id}; You have "references" in your tsconfig file. Perhaps you want to add \`dts: { build: true }\` in your config?`,
       )
     }
 

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -57,7 +57,7 @@ describe('tsc', () => {
     expect(snapshot).toMatchSnapshot()
   })
 
-  test.fails('composite projects sourcemap #80', async () => {
+  test('composite projects sourcemap #80', async () => {
     const root = path.resolve(dirname, 'fixtures/composite-refs-sourcemap')
 
     const { chunks } = await rolldownBuild(


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description



This PR completely rewrites how tsc emit works by creating separate paths for regular `tsc` and `tsc --build` modes.

## Previous Design

When `dts.build` is true:

1. Build all related projects using `tsc --build`
2. Find which project contains the target file
3. Create a `ts.Program` from that project
4. Generate declaration files from the program

This design was problematic and only existed to reuse existing `ts.Program` code. This caused issues like incorrect source map paths in #80. 

## New Design

The refactor creates two clear workflows:

- `tscEmitClassic`: Handles `tsc` mode, using existing `ts.Program` code.
- `tscEmitBuild`: Handles `tsc --build` mode.

When `dts.build` is true:

1. Build all related projects using `tsc --build` (if not already built)
2. Find which project contains the target file (e.g., `src/index.ts`)
3. Find the expected output file paths (e.g., `dist/index.d.ts` and `dist/index.d.ts.map`)
4. Directly read the output file from memory or disk


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Closes #80 

### Additional context

N/A

<!-- e.g. is there anything you'd like reviewers to focus on? -->
