### PR TITLE
refactor: move tsc transformer to a separate file

### DIFF
--- a/src/tsc/transformer.ts
+++ b/src/tsc/transformer.ts
@@ -1,0 +1,25 @@
+import ts from 'typescript'
+
+// fix #77
+const stripPrivateFields: ts.TransformerFactory<ts.SourceFile | ts.Bundle> = (
+  ctx,
+) => {
+  const visitor = (node: ts.Node) => {
+    if (ts.isPropertySignature(node) && ts.isPrivateIdentifier(node.name)) {
+      return ctx.factory.updatePropertySignature(
+        node,
+        node.modifiers,
+        ctx.factory.createStringLiteral(node.name.text),
+        node.questionToken,
+        node.type,
+      )
+    }
+    return ts.visitEachChild(node, visitor, ctx)
+  }
+  return (sourceFile) =>
+    ts.visitNode(sourceFile, visitor, ts.isSourceFile) ?? sourceFile
+}
+
+export const customTransformers: ts.CustomTransformers = {
+  afterDeclarations: [stripPrivateFields],
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Move existing `stripPrivateFields` function out of `tscEmit`. This makes it easier to re-use it later for `tsc --build` path in my another pull request. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

N/A

### Additional context

N/A

<!-- e.g. is there anything you'd like reviewers to focus on? -->
