### PR TITLE
fix: remap paths in source maps

### DIFF
--- a/src/tsc/emit-build.ts
+++ b/src/tsc/emit-build.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-import { pathToFileURL } from 'node:url'
 import Debug from 'debug'
 import ts from 'typescript'
 import {
@@ -9,7 +7,7 @@ import {
   type TscContext,
 } from './context.ts'
 import { createFsSystem, createMemorySystem } from './system.ts'
-import { customTransformers, formatHost } from './utils.ts'
+import { customTransformers, formatHost, setSourceMapRoot } from './utils.ts'
 import type { TscOptions, TscResult } from './types.ts'
 import type { ExistingRawSourceMap } from 'rolldown'
 
@@ -94,22 +92,7 @@ export function tscEmitBuild(tscOptions: TscOptions): TscResult {
       }
 
       map = JSON.parse(text)
-      if (!map || map.sourceRoot) {
-        continue
-      }
-
-      // Since `outputFile` and `resolvedId` might locate in different
-      // directories, we need to explicitly set the `sourceRoot` of the source
-      // map so that the final sourcemap has correct paths in `sources` field.
-      const outputFileDir = path.posix.dirname(
-        pathToFileURL(outputFile).pathname,
-      )
-      const resolvedIdDir = path.posix.dirname(
-        pathToFileURL(resolvedId).pathname,
-      )
-      if (outputFileDir !== resolvedIdDir) {
-        map.sourceRoot = path.posix.relative(resolvedIdDir, outputFileDir)
-      }
+      setSourceMapRoot(map, outputFile, resolvedId)
     }
   }
 

--- a/src/tsc/emit-compiler.ts
+++ b/src/tsc/emit-compiler.ts
@@ -3,10 +3,10 @@ import Debug from 'debug'
 import ts from 'typescript'
 import { globalContext } from './context.ts'
 import { createFsSystem } from './system.ts'
-import { customTransformers, formatHost } from './utils.ts'
+import { customTransformers, formatHost, setSourceMapRoot } from './utils.ts'
 import { createVueProgramFactory } from './vue.ts'
 import type { TscModule, TscOptions, TscResult } from './types.ts'
-import type { SourceMapInput } from 'rolldown'
+import type { ExistingRawSourceMap } from 'rolldown'
 
 const debug = Debug('rolldown-plugin-dts:tsc-compiler')
 
@@ -150,7 +150,7 @@ export function tscEmitCompiler(tscOptions: TscOptions): TscResult {
   const { program, file } = module
   debug(`got source file: ${file.fileName}`)
   let dtsCode: string | undefined
-  let map: SourceMapInput | undefined
+  let map: ExistingRawSourceMap | undefined
 
   const { emitSkipped, diagnostics } = program.emit(
     file,
@@ -158,6 +158,7 @@ export function tscEmitCompiler(tscOptions: TscOptions): TscResult {
       if (fileName.endsWith('.map')) {
         debug(`emit dts sourcemap: ${fileName}`)
         map = JSON.parse(code)
+        setSourceMapRoot(map, fileName, tscOptions.id)
       } else {
         debug(`emit dts: ${fileName}`)
         dtsCode = code

--- a/tests/__snapshots__/tsc.test.ts.snap
+++ b/tests/__snapshots__/tsc.test.ts.snap
@@ -8,7 +8,7 @@ declare const a = 1;
 export { a };
 //# sourceMappingURL=index.d.ts.map
 // index.d.ts.map
-{"version":3,"file":"index.d.ts","names":[],"sources":["../../../../../../../../../src/index.ts"],"sourcesContent":[],"mappings":";cAAa,CAAA"}
+{"version":3,"file":"index.d.ts","names":[],"sources":["../src/index.ts"],"sourcesContent":[],"mappings":";cAAa,CAAA"}
 // index.js
 //#region tests/fixtures/deep-source-map/src/index.ts
 const a = 1;

--- a/tests/__snapshots__/tsc.test.ts.snap
+++ b/tests/__snapshots__/tsc.test.ts.snap
@@ -1,5 +1,45 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`tsc > compiler project sourcemap (build: false) 2`] = `
+"// index.d.ts
+//#region tests/fixtures/deep-source-map/src/index.d.ts
+declare const a = 1;
+//#endregion
+export { a };
+//# sourceMappingURL=index.d.ts.map
+// index.d.ts.map
+{"version":3,"file":"index.d.ts","names":[],"sources":["../../../../../../../../../src/index.ts"],"sourcesContent":[],"mappings":";cAAa,CAAA"}
+// index.js
+//#region tests/fixtures/deep-source-map/src/index.ts
+const a = 1;
+
+//#endregion
+export { a };
+//# sourceMappingURL=index.js.map
+// index.js.map
+{"version":3,"file":"index.js","names":[],"sources":["../src/index.ts"],"sourcesContent":["export const a = 1\\n"],"mappings":";AAAA,MAAa,IAAI"}"
+`;
+
+exports[`tsc > compiler project sourcemap (build: true) 2`] = `
+"// index.d.ts
+//#region tests/fixtures/deep-source-map/src/index.d.ts
+declare const a = 1;
+//#endregion
+export { a };
+//# sourceMappingURL=index.d.ts.map
+// index.d.ts.map
+{"version":3,"file":"index.d.ts","names":["a"],"sources":["../src/index.d.ts"],"sourcesContent":["export declare const a = 1;\\n"],"mappings":";cAAqBA,CAAAA"}
+// index.js
+//#region tests/fixtures/deep-source-map/src/index.ts
+const a = 1;
+
+//#endregion
+export { a };
+//# sourceMappingURL=index.js.map
+// index.js.map
+{"version":3,"file":"index.js","names":[],"sources":["../src/index.ts"],"sourcesContent":["export const a = 1\\n"],"mappings":";AAAA,MAAa,IAAI"}"
+`;
+
 exports[`tsc > composite references 1`] = `
 "// input1.d.ts
 //#region tests/fixtures/composite-refs/dir1/input1.d.ts

--- a/tests/fixtures/deep-source-map/src/index.ts
+++ b/tests/fixtures/deep-source-map/src/index.ts
@@ -1,0 +1,1 @@
+export const a = 1

--- a/tests/fixtures/deep-source-map/tsconfig.json
+++ b/tests/fixtures/deep-source-map/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "esnext",
+    "outDir": "./dist/deep/nested/output/directory/1/2/3/4/5/6/7/8/9/10",
+    "types": [],
+    "strict": true,
+  }
+}

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -73,9 +73,10 @@ describe('tsc', () => {
       { dir: path.resolve(root, 'dist') },
     )
     const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    expect(sourcemap.sourceRoot).toBeFalsy()
     expect(sourcemap.sources).toMatchInlineSnapshot(`
       [
-        "../../../../../../../../../src/index.ts",
+        "../src/index.ts",
       ]
     `)
     expect(snapshot).toMatchSnapshot()
@@ -96,6 +97,7 @@ describe('tsc', () => {
       { dir: path.resolve(root, 'dist') },
     )
     const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    expect(sourcemap.sourceRoot).toBeFalsy()
     expect(sourcemap.sources).toMatchInlineSnapshot(`
       [
         "../src/index.d.ts",

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -124,9 +124,7 @@ describe('tsc', () => {
     )
 
     const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
-    const sources: string[] = (sourcemap.sources || [])
-      .filter((s) => s != null)
-      .map((s: string) => s.replaceAll('\\\\', '/'))
+    const sources = sourcemap.sources || []
     const expectedSources = ['../../src/types.ts', '../../src/react/index.ts']
     expect(sources.sort()).toEqual(expectedSources.sort())
     expect(sourcemap.sourcesContent).toBeOneOf([undefined, []])

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -5,6 +5,7 @@ import { rolldownBuild } from '@sxzz/test-utils'
 import { glob } from 'tinyglobby'
 import { describe, expect, test } from 'vitest'
 import { dts } from '../src/index.ts'
+import { findSourceMapChunk } from './utils.ts'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -57,6 +58,52 @@ describe('tsc', () => {
     expect(snapshot).toMatchSnapshot()
   })
 
+  test('compiler project sourcemap (build: false)', async () => {
+    const root = path.resolve(dirname, 'fixtures/deep-source-map')
+    const { snapshot, chunks } = await rolldownBuild(
+      [path.resolve(root, 'src/index.ts')],
+      [
+        dts({
+          tsconfig: path.resolve(root, 'tsconfig.json'),
+          sourcemap: true,
+          build: false,
+        }),
+      ],
+      {},
+      { dir: path.resolve(root, 'dist') },
+    )
+    const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    expect(sourcemap.sources).toMatchInlineSnapshot(`
+      [
+        "../../../../../../../../../src/index.ts",
+      ]
+    `)
+    expect(snapshot).toMatchSnapshot()
+  })
+
+  test('compiler project sourcemap (build: true)', async () => {
+    const root = path.resolve(dirname, 'fixtures/deep-source-map')
+    const { snapshot, chunks } = await rolldownBuild(
+      [path.resolve(root, 'src/index.ts')],
+      [
+        dts({
+          tsconfig: path.resolve(root, 'tsconfig.json'),
+          sourcemap: true,
+          build: true,
+        }),
+      ],
+      {},
+      { dir: path.resolve(root, 'dist') },
+    )
+    const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    expect(sourcemap.sources).toMatchInlineSnapshot(`
+      [
+        "../src/index.d.ts",
+      ]
+    `)
+    expect(snapshot).toMatchSnapshot()
+  })
+
   test('composite projects sourcemap #80', async () => {
     const root = path.resolve(dirname, 'fixtures/composite-refs-sourcemap')
 
@@ -74,24 +121,10 @@ describe('tsc', () => {
       { dir: path.resolve(root, 'actual-output/react') },
     )
 
-    const sourcemapChunk = chunks.find((chunk) =>
-      chunk.fileName.endsWith('.d.ts.map'),
-    )
-
-    if (!sourcemapChunk) {
-      throw new Error('Sourcemap chunk not found')
-    }
-    if (sourcemapChunk.type !== 'asset') {
-      throw new Error('Sourcemap chunk is not an asset')
-    }
-    if (typeof sourcemapChunk.source !== 'string') {
-      throw new TypeError('Sourcemap chunk source is not a string')
-    }
-
-    const sourcemap = JSON.parse(sourcemapChunk.source)
-    const sources: string[] = sourcemap.sources.map((s: string) =>
-      s.replaceAll('\\\\', '/'),
-    )
+    const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    const sources: string[] = (sourcemap.sources || [])
+      .filter((s) => s != null)
+      .map((s: string) => s.replaceAll('\\\\', '/'))
     const expectedSources = ['../../src/types.ts', '../../src/react/index.ts']
     expect(sources.sort()).toEqual(expectedSources.sort())
     expect(sourcemap.sourcesContent).toBeOneOf([undefined, []])

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,28 @@
+import type { ExistingRawSourceMap, RolldownOutput } from 'rolldown'
+
+/**
+ * Find and parse a source map from the output chunks
+ */
+export function findSourceMapChunk(
+  chunks: RolldownOutput['output'],
+  fileName: string,
+): ExistingRawSourceMap {
+  const chunk = chunks.find((chunk) => chunk.fileName === fileName)
+
+  if (!chunk) {
+    throw new Error(
+      `Unable to find file ${fileName} from the following chunks: ${chunks.map((chunk) => chunk.fileName).join(', ')}`,
+    )
+  }
+
+  if (chunk.type !== 'asset') {
+    throw new Error('Sourcemap chunk is not an asset')
+  }
+
+  if (typeof chunk.source !== 'string') {
+    throw new TypeError('Sourcemap chunk source is not a string')
+  }
+
+  const map = JSON.parse(chunk.source) as ExistingRawSourceMap
+  return map
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

If the output directory in `tsconfig.json` differs from the output directory in the rolldown config, the resulting `.d.ts.map` will contain incorrect relative source paths. These inaccuracies can hinder VSCode's "Go to definition" feature from finding the appropriate `.ts` files.

This PR addresses the issue by configuring the `sourceRoot` field in the generated source map from `tsc`. When this source map is subsequently passed to `rolldown`, the correct final paths can be determined.




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


### Linked Issues


Closes https://github.com/rolldown/tsdown/issues/475 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
