### PR TITLE
fix: use `entryFileNames` for entry dts chunks

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -71,13 +71,15 @@ export function createFakeJsPlugin({
           '[rolldown-plugin-dts] Cannot bundle dts files with `cjs` format.',
         )
       }
-      const { chunkFileNames } = options
+      const { chunkFileNames, entryFileNames } = options
       return {
         ...options,
         sourcemap: options.sourcemap || sourcemap,
         chunkFileNames(chunk) {
           const nameTemplate = resolveTemplateFn(
-            chunkFileNames || '[name]-[hash].js',
+            chunk.isEntry
+              ? entryFileNames || '[name].js'
+              : chunkFileNames || '[name]-[hash].js',
             chunk,
           )
 


### PR DESCRIPTION
### Description

Chunks created via `emitFile({ type: 'chunk' })` were using the `chunkFileNames` template (which includes `[hash]`) instead of `entryFileNames`.

### Linked Issues

rolldown/rolldown#6674

