### PR TITLE
Fix `tsc-worker` Extension

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   platform: 'node',
   dts: false,
   define: {
-    'import.meta.WORKER_URL': JSON.stringify('./tsc-worker.js'),
+    'import.meta.WORKER_URL': JSON.stringify('./tsc-worker.mjs'),
   },
   exports: true,
   plugins: [


### PR DESCRIPTION
The `tsc-worker` path definition in the build config is not using the correct file extension.