### PR TITLE
fix: fake-js collectParams Babel 7 backwards compatibility

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -522,7 +522,9 @@ export function createFakeJsPlugin({
           node.typeParameters?.type === 'TSTypeParameterDeclaration'
         ) {
           typeParams.push(
-            ...node.typeParameters.params.map((param) => param.name),
+            ...node.typeParameters.params.map(({ name }) =>
+              typeof name === 'string' ? t.identifier(name) : name,
+            ),
           )
         }
       },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [ ] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

There was a [breaking change](https://github.com/babel/babel/pull/12829) in Babel 8 that changed TSTypeParameter.name from a string to an Identifier. For projects with babel version overrides, this causes `collectParams` to include undefined `name` entries. If this project is open to supporting Babel 7 until version 8 has a stable release, this change would be much appreciated.

### Linked Issues

https://github.com/babel/babel/pull/12829

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
