### PR TITLE
fix: rewrite local `declare module` specifiers to output chunk paths

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { generate } from '@babel/generator'
 import { isIdentifierName } from '@babel/helper-validator-identifier'
 import { parse, type ParseResult } from '@babel/parser'
@@ -11,6 +12,7 @@ import {
 import {
   filename_dts_to,
   filename_js_to_dts,
+  filename_to_dts,
   RE_DTS,
   RE_DTS_MAP,
   RE_NODE_MODULES,
@@ -52,6 +54,7 @@ interface DeclarationInfo {
   params: TypeParams
   deps: Dep[]
   children: t.Node[]
+  resolvedModuleId?: string
 }
 
 interface ModuleExports {
@@ -86,6 +89,8 @@ type NamespaceMap = Map<
     local: t.Identifier | t.TSQualifiedName
   }
 >
+
+const CROSS_CHUNK_PLACEHOLDER = '__rolldown_dts_resolve__:'
 
 export function createFakeJsPlugin({
   sourcemap,
@@ -148,6 +153,37 @@ export function createFakeJsPlugin({
     renderChunk,
 
     generateBundle(options, bundle) {
+      // Build moduleId → chunk.fileName mapping
+      const moduleToChunk = new Map<string, string>()
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk') continue
+        for (const moduleId of chunk.moduleIds) {
+          moduleToChunk.set(moduleId, chunk.fileName)
+        }
+      }
+
+      // Rewrite `declare module` placeholders to output chunk paths
+      const placeholderRe = new RegExp(`"${CROSS_CHUNK_PLACEHOLDER}(.+?)"`, 'g')
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk' || !RE_DTS.test(chunk.fileName)) continue
+        if (!chunk.code.includes(CROSS_CHUNK_PLACEHOLDER)) continue
+
+        chunk.code = chunk.code.replaceAll(
+          placeholderRe,
+          (_match, resolvedId: string) => {
+            const targetFileName = moduleToChunk.get(resolvedId)
+            if (!targetFileName) return _match
+            let specifier = path.posix.relative(
+              path.posix.dirname(chunk.fileName),
+              targetFileName,
+            )
+            if (!specifier.startsWith('.')) specifier = `./${specifier}`
+            specifier = filename_dts_to(specifier, 'js')
+            return JSON.stringify(specifier)
+          },
+        )
+      }
+
       for (const chunk of Object.values(bundle)) {
         if (!RE_DTS_MAP.test(chunk.fileName)) continue
 
@@ -212,14 +248,20 @@ export function createFakeJsPlugin({
       const sideEffect =
         stmt.type === 'TSModuleDeclaration' && stmt.kind !== 'namespace'
 
-      if (
-        sideEffect &&
-        stmt.id.type === 'StringLiteral' &&
-        stmt.id.value[0] === '.'
-      ) {
-        this.warn(
-          `\`declare module ${JSON.stringify(stmt.id.value)}\` will be kept as-is in the output. Relative module declaration may cause unexpected issues. Found in ${id}.`,
-        )
+      // Resolve local `declare module './foo'` targets so that specifiers
+      // can be rewritten to point to the correct output chunk.
+      let resolvedModuleId: string | undefined
+      if (sideEffect && stmt.id.type === 'StringLiteral') {
+        const resolved = await this.resolve(stmt.id.value, id)
+        if (resolved && !resolved.external) {
+          resolvedModuleId = RE_DTS.test(resolved.id)
+            ? resolved.id
+            : filename_to_dts(resolved.id)
+        } else if (stmt.id.value[0] === '.') {
+          this.warn(
+            `\`declare module ${JSON.stringify(stmt.id.value)}\` will be kept as-is in the output. Relative module declaration may cause unexpected issues. Found in ${id}.`,
+          )
+        }
       }
 
       if (
@@ -315,6 +357,7 @@ export function createFakeJsPlugin({
         bindings,
         params,
         children,
+        resolvedModuleId,
       })
 
       const declarationIdNode: t.NumericLiteral = {
@@ -535,6 +578,15 @@ export function createFakeJsPlugin({
           } else {
             Object.assign(originalDep, transformedDep)
           }
+        }
+
+        // Rewrite local `declare module` specifier → placeholder for generateBundle
+        if (
+          declaration.decl.type === 'TSModuleDeclaration' &&
+          declaration.resolvedModuleId
+        ) {
+          ;(declaration.decl.id as t.StringLiteral).value =
+            CROSS_CHUNK_PLACEHOLDER + declaration.resolvedModuleId
         }
 
         return inheritNodeComments(node, declaration.decl)

--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { generate } from '@babel/generator'
 import { isIdentifierName } from '@babel/helper-validator-identifier'
 import { parse, type ParseResult } from '@babel/parser'
@@ -12,6 +13,7 @@ import {
 import {
   filename_dts_to,
   filename_js_to_dts,
+  filename_to_dts,
   RE_DTS,
   RE_DTS_MAP,
   replaceTemplateName,
@@ -51,6 +53,7 @@ interface DeclarationInfo {
   params: TypeParams
   deps: Dep[]
   children: t.Node[]
+  resolvedModuleId?: string
 }
 
 type NamespaceMap = Map<
@@ -60,6 +63,8 @@ type NamespaceMap = Map<
     local: t.Identifier | t.TSQualifiedName
   }
 >
+
+const CROSS_CHUNK_PLACEHOLDER = '__rolldown_dts_resolve__:'
 
 export function createFakeJsPlugin({
   sourcemap,
@@ -121,6 +126,37 @@ export function createFakeJsPlugin({
     renderChunk,
 
     generateBundle(options, bundle) {
+      // Build moduleId → chunk.fileName mapping
+      const moduleToChunk = new Map<string, string>()
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk') continue
+        for (const moduleId of chunk.moduleIds) {
+          moduleToChunk.set(moduleId, chunk.fileName)
+        }
+      }
+
+      // Rewrite `declare module` placeholders to output chunk paths
+      const placeholderRe = new RegExp(`"${CROSS_CHUNK_PLACEHOLDER}(.+?)"`, 'g')
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk' || !RE_DTS.test(chunk.fileName)) continue
+        if (!chunk.code.includes(CROSS_CHUNK_PLACEHOLDER)) continue
+
+        chunk.code = chunk.code.replaceAll(
+          placeholderRe,
+          (_match, resolvedId: string) => {
+            const targetFileName = moduleToChunk.get(resolvedId)
+            if (!targetFileName) return _match
+            let specifier = path.posix.relative(
+              path.posix.dirname(chunk.fileName),
+              targetFileName,
+            )
+            if (!specifier.startsWith('.')) specifier = `./${specifier}`
+            specifier = filename_dts_to(specifier, 'js')
+            return JSON.stringify(specifier)
+          },
+        )
+      }
+
       for (const chunk of Object.values(bundle)) {
         if (!RE_DTS_MAP.test(chunk.fileName)) continue
 
@@ -137,11 +173,11 @@ export function createFakeJsPlugin({
     },
   }
 
-  function transform(
+  async function transform(
     this: TransformPluginContext,
     code: string,
     id: string,
-  ): TransformResult {
+  ): Promise<TransformResult> {
     let file: ParseResult
     try {
       file = parse(code, {
@@ -176,14 +212,20 @@ export function createFakeJsPlugin({
       const sideEffect =
         stmt.type === 'TSModuleDeclaration' && stmt.kind !== 'namespace'
 
-      if (
-        sideEffect &&
-        stmt.id.type === 'StringLiteral' &&
-        stmt.id.value[0] === '.'
-      ) {
-        this.warn(
-          `\`declare module ${JSON.stringify(stmt.id.value)}\` will be kept as-is in the output. Relative module declaration may cause unexpected issues. Found in ${id}.`,
-        )
+      // Resolve local `declare module './foo'` targets so that specifiers
+      // can be rewritten to point to the correct output chunk.
+      let resolvedModuleId: string | undefined
+      if (sideEffect && stmt.id.type === 'StringLiteral') {
+        const resolved = await this.resolve(stmt.id.value, id)
+        if (resolved && !resolved.external) {
+          resolvedModuleId = RE_DTS.test(resolved.id)
+            ? resolved.id
+            : filename_to_dts(resolved.id)
+        } else if (stmt.id.value[0] === '.') {
+          this.warn(
+            `\`declare module ${JSON.stringify(stmt.id.value)}\` will be kept as-is in the output. Relative module declaration may cause unexpected issues. Found in ${id}.`,
+          )
+        }
       }
 
       if (
@@ -273,6 +315,7 @@ export function createFakeJsPlugin({
         bindings,
         params,
         children,
+        resolvedModuleId,
       })
 
       const declarationIdNode = t.numericLiteral(declarationId)
@@ -470,6 +513,15 @@ export function createFakeJsPlugin({
           } else {
             Object.assign(originalDep, transformedDep)
           }
+        }
+
+        // Rewrite local `declare module` specifier → placeholder for generateBundle
+        if (
+          declaration.decl.type === 'TSModuleDeclaration' &&
+          declaration.resolvedModuleId
+        ) {
+          ;(declaration.decl.id as t.StringLiteral).value =
+            CROSS_CHUNK_PLACEHOLDER + declaration.resolvedModuleId
         }
 
         return inheritNodeComments(node, declaration.decl)

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -111,6 +111,62 @@ declare module "virtual" {
 }"
 `;
 
+exports[`declare relative module 1`] = `
+"// main-bar.d.ts
+//#region tests/fixtures/declare-relative-module/foobar/foo.d.ts
+interface FooBar {
+  foobar: string;
+}
+//#endregion
+//#region tests/fixtures/declare-relative-module/foobar/index.d.ts
+declare module "./main-bar.js" {
+  interface FooBar {
+    foobar2: string;
+  }
+}
+//#endregion
+//#region tests/fixtures/declare-relative-module/foobaz.d.ts
+declare module "./main-bar.js" {
+  interface Bar {
+    bar2: string;
+  }
+}
+interface FooBaz {
+  foobaz: string;
+}
+//#endregion
+//#region tests/fixtures/declare-relative-module/bar.d.ts
+declare module "./main-foo.js" {
+  interface Foo {
+    foo2: string;
+  }
+}
+interface Bar {
+  bar: string;
+}
+//#endregion
+export { Bar, FooBar, FooBaz };
+// main-baz/index.d.ts
+//#region tests/fixtures/declare-relative-module/baz/index.d.ts
+declare module "../main-foo.js" {
+  interface Foo {
+    baz: string;
+  }
+}
+interface Baz {
+  baz: string;
+}
+//#endregion
+export { Baz };
+// main-foo.d.ts
+//#region tests/fixtures/declare-relative-module/foo.d.ts
+interface Foo {
+  foo: string;
+}
+//#endregion
+export { Foo };"
+`;
+
 exports[`decorators 1`] = `
 "// decorator.d.ts
 //#region tests/fixtures/decorator.d.ts

--- a/tests/fixtures/declare-relative-module/bar.ts
+++ b/tests/fixtures/declare-relative-module/bar.ts
@@ -1,0 +1,12 @@
+export * from './foobar/index.js'
+export * from './foobaz.js'
+
+declare module './foo.js' {
+  interface Foo {
+    foo2: string
+  }
+}
+
+export interface Bar {
+  bar: string
+}

--- a/tests/fixtures/declare-relative-module/baz/index.ts
+++ b/tests/fixtures/declare-relative-module/baz/index.ts
@@ -1,0 +1,9 @@
+declare module '../foo.js' {
+  interface Foo {
+    baz: string
+  }
+}
+
+export interface Baz {
+  baz: string
+}

--- a/tests/fixtures/declare-relative-module/foo.ts
+++ b/tests/fixtures/declare-relative-module/foo.ts
@@ -1,0 +1,3 @@
+export interface Foo {
+  foo: string
+}

--- a/tests/fixtures/declare-relative-module/foobar/foo.ts
+++ b/tests/fixtures/declare-relative-module/foobar/foo.ts
@@ -1,0 +1,3 @@
+export interface FooBar {
+  foobar: string
+}

--- a/tests/fixtures/declare-relative-module/foobar/index.ts
+++ b/tests/fixtures/declare-relative-module/foobar/index.ts
@@ -1,0 +1,7 @@
+export * from './foo.js'
+
+declare module './foo.js' {
+  interface FooBar {
+    foobar2: string
+  }
+}

--- a/tests/fixtures/declare-relative-module/foobaz.ts
+++ b/tests/fixtures/declare-relative-module/foobaz.ts
@@ -1,0 +1,9 @@
+declare module './bar.js' {
+  interface Bar {
+    bar2: string
+  }
+}
+
+export interface FooBaz {
+  foobaz: string
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -446,6 +446,19 @@ test('declare module', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+test('declare relative module', async () => {
+  const fixture = path.resolve(dirname, 'fixtures/declare-relative-module')
+  const { snapshot } = await rolldownBuild(
+    {
+      'main-foo': path.resolve(fixture, 'foo.ts'),
+      'main-bar': path.resolve(fixture, 'bar.ts'),
+      'main-baz/index': path.resolve(fixture, 'baz/index.ts'),
+    },
+    [dts({ emitDtsOnly: true })],
+  )
+  expect(snapshot).toMatchSnapshot()
+})
+
 test('should error when file import cannot be found', async () => {
   await expect(() =>
     rolldownBuild(path.resolve(dirname, 'fixtures/unresolved-import/ts.ts'), [

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -523,6 +523,19 @@ test('declare module', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+test('declare relative module', async () => {
+  const fixture = path.resolve(dirname, 'fixtures/declare-relative-module')
+  const { snapshot } = await rolldownBuild(
+    {
+      'main-foo': path.resolve(fixture, 'foo.ts'),
+      'main-bar': path.resolve(fixture, 'bar.ts'),
+      'main-baz/index': path.resolve(fixture, 'baz/index.ts'),
+    },
+    [dts({ emitDtsOnly: true })],
+  )
+  expect(snapshot).toMatchSnapshot()
+})
+
 test('should error when file import cannot be found', async () => {
   await expect(() =>
     rolldownBuild(path.resolve(dirname, 'fixtures/unresolved-import/ts.ts'), [


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [x] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

When `declare module './foo.js'` or `declare module '@/foo.js'` references a local file, the specifier was preserved as-is in the bundled `.d.ts` output. This made the augmentation unreachable for consumers since the internal path no longer resolves after bundling.

Now resolves local `declare module` targets and rewrites their specifiers to the relative path of the output chunk containing the target module.

#### How it works

1. `transform` - resolves all `declare module` string literal specifiers using `this.resolve()`. If the target is a local (non-external) module, stores the resolved module ID in the declaration metadata.
2. `renderChunk` - replaces resolved specifiers with an internal placeholder.
3. `generateBundle` - builds a module-to-chunk mapping and rewrites placeholders to the correct relative path between output chunks.

This approach works for both same-chunk (self-referencing) and cross-chunk augmentations, as well as tsconfig path aliases like `@/foo.js`.

#### Test plan

- New test case with cross-chunk rewrites, subfolder resolution, and same-chunk self-references
- Existing `declare module` test (ambient `declare module 'virtual'`) still passes unchanged
- Full test suite (194 tests), lint, typecheck all pass

### Linked Issues

Fixes #134

### Additional context

While the original ticket #134 mentions same-chunk references being replaced with `declare module '.'`, I couldn't get that working with TypeScript. This PR rewrites same-chunk specifiers as `declare module './current-chunk.js'` instead.