### PR TITLE
fix: support array inputs and fixed-string entryFileNames 

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -128,18 +128,7 @@ export function createGeneratePlugin({
         }
       }
 
-      if (!Array.isArray(options.input)) {
-        for (const [name, id] of Object.entries(options.input)) {
-          debug('resolving input alias %s -> %s', name, id)
-          let resolved = await this.resolve(id)
-          if (!id.startsWith('./')) {
-            resolved ||= await this.resolve(`./${id}`)
-          }
-          const resolvedId = resolved?.id || id
-          debug('resolved input alias %s -> %s', id, resolvedId)
-          inputAliasMap.set(resolvedId, name)
-        }
-      } else {
+      if (Array.isArray(options.input)) {
         for (const id of options.input) {
           debug('resolving array input %s', id)
           let resolved = await this.resolve(id)
@@ -148,7 +137,23 @@ export function createGeneratePlugin({
           }
           const resolvedId = resolved?.id || id
           const name = path.basename(resolvedId).replace(RE_TS, '')
-          debug('resolved array input %s -> %s (name: %s)', id, resolvedId, name)
+          debug(
+            'resolved array input %s -> %s (name: %s)',
+            id,
+            resolvedId,
+            name,
+          )
+          inputAliasMap.set(resolvedId, name)
+        }
+      } else {
+        for (const [name, id] of Object.entries(options.input)) {
+          debug('resolving input alias %s -> %s', name, id)
+          let resolved = await this.resolve(id)
+          if (!id.startsWith('./')) {
+            resolved ||= await this.resolve(`./${id}`)
+          }
+          const resolvedId = resolved?.id || id
+          debug('resolved input alias %s -> %s', id, resolvedId)
           inputAliasMap.set(resolvedId, name)
         }
       }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -6,6 +6,7 @@ import { parse } from '@babel/parser'
 import { createDebug } from 'obug'
 import { isolatedDeclarationSync } from 'rolldown/experimental'
 import {
+  filename_js_to_dts,
   filename_to_dts,
   RE_DTS,
   RE_DTS_MAP,
@@ -138,6 +139,18 @@ export function createGeneratePlugin({
           debug('resolved input alias %s -> %s', id, resolvedId)
           inputAliasMap.set(resolvedId, name)
         }
+      } else {
+        for (const id of options.input) {
+          debug('resolving array input %s', id)
+          let resolved = await this.resolve(id)
+          if (!id.startsWith('./')) {
+            resolved ||= await this.resolve(`./${id}`)
+          }
+          const resolvedId = resolved?.id || id
+          const name = path.basename(resolvedId).replace(RE_TS, '')
+          debug('resolved array input %s -> %s (name: %s)', id, resolvedId, name)
+          inputAliasMap.set(resolvedId, name)
+        }
       }
     },
 
@@ -155,6 +168,14 @@ export function createGeneratePlugin({
             if (RE_DTS.test(nameTemplate)) {
               return replaceTemplateName(nameTemplate, chunk.name.slice(0, -2))
             }
+
+            const renderedNameWithoutD = filename_js_to_dts(
+              replaceTemplateName(nameTemplate, chunk.name.slice(0, -2)),
+            )
+            if (RE_DTS.test(renderedNameWithoutD)) {
+              return renderedNameWithoutD
+            }
+
             if (RE_JS.test(nameTemplate)) {
               return nameTemplate.replace(RE_JS, '.$1ts')
             }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -592,6 +592,86 @@ test('deterministic namespace import index', async () => {
   expect(results[0]).not.toContain('stub_lib0')
 })
 
+describe('array input with fixed entryFileNames', () => {
+  test('array input produces correct .d.ts filenames', async () => {
+    const { chunks } = await rolldownBuild(
+      [path.resolve(dirname, 'fixtures/basic.ts')],
+      [dts()],
+      {},
+      { entryFileNames: '[name].mjs' },
+    )
+
+    const chunkNames = chunks.map((chunk) => chunk.fileName).toSorted()
+    expect(chunkNames).toStrictEqual(['basic.d.mts', 'basic.mjs'])
+  })
+
+  test('fixed-string entryFileNames (Vite lib mode)', async () => {
+    const { chunks } = await rolldownBuild(
+      [path.resolve(dirname, 'fixtures/basic.ts')],
+      [dts()],
+      {},
+      { entryFileNames: () => 'index.mjs' },
+    )
+
+    const chunkNames = chunks.map((chunk) => chunk.fileName).toSorted()
+    expect(chunkNames).toContain('index.d.mts')
+    expect(chunkNames).toContain('index.mjs')
+  })
+
+  test('fixed-string entryFileNames .cjs', async () => {
+    const { chunks } = await rolldownBuild(
+      [path.resolve(dirname, 'fixtures/basic.ts')],
+      [dts()],
+      {},
+      { entryFileNames: () => 'index.cjs' },
+    )
+
+    const chunkNames = chunks.map((chunk) => chunk.fileName).toSorted()
+    expect(chunkNames).toContain('index.d.cts')
+    expect(chunkNames).toContain('index.cjs')
+  })
+
+  test('fixed-string entryFileNames .js', async () => {
+    const { chunks } = await rolldownBuild(
+      [path.resolve(dirname, 'fixtures/basic.ts')],
+      [dts()],
+      {},
+      { entryFileNames: () => 'index.js' },
+    )
+
+    const chunkNames = chunks.map((chunk) => chunk.fileName).toSorted()
+    expect(chunkNames).toContain('index.d.ts')
+    expect(chunkNames).toContain('index.js')
+  })
+
+  test('input alias with fixed-string entryFileNames', async () => {
+    const root = path.resolve(dirname, 'fixtures/alias')
+    const { chunks } = await rolldownBuild(
+      { index: 'input1.ts' },
+      [dts({ emitDtsOnly: true })],
+      { cwd: root },
+      { entryFileNames: () => 'lib.mjs' },
+    )
+
+    const chunkNames = chunks.map((chunk) => chunk.fileName).toSorted()
+    expect(chunkNames).toContain('lib.d.mts')
+  })
+
+  test('array input + fixed-string entryFileNames (Vite 8 lib mode)', async () => {
+    const root = path.resolve(dirname, 'fixtures/alias')
+    const { chunks, snapshot } = await rolldownBuild(
+      ['input1.ts'],
+      [dts({ emitDtsOnly: true })],
+      { cwd: root },
+      { entryFileNames: () => 'index.mjs' },
+    )
+
+    const chunkNames = chunks.map((chunk) => chunk.fileName).toSorted()
+    expect(chunkNames).toContain('index.d.mts')
+    expect(snapshot).not.toMatch(/\[\d+,\s*\(\)/)
+  })
+})
+
 test('decorators', async () => {
   const { snapshot } = await rolldownBuild(
     path.resolve(dirname, 'fixtures/decorator.ts'),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

I'm not super familiar with the rolldown plugin internals, so I used Claude Code to help trace issue back through plugin hooks, understand fake-js architecture, and validate that my fix was correct and backward-compatible (hopefully).

So, I'm checking those boxes:

- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
- [x] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

Hey! I ran into this while migrating monorepo from `vite-plugin-dts` + `@microsoft/api-extractor` to `rolldown-plugin-dts`. After building some packages with Vite 8 in lib mode output `.mts` files had raw fakejs arrays like `[1, () => [...]]` instead of actual TypeScript declarations. Downstream packages could not type-check at all.

## What was happening

I'm not super familiar with the rolldown plugin internals, so it took some digging. I added debug logging to hooks and traced it down to two possible separate "bugs" (once again, I was fixing problem I've faced, not sure if it's generic and it makes sense to push it as fix) that combine together in Vite 8 lib mode:

**Array inputs not handled in `buildStart`**

Vite 8 passes `options.input` as array (`['src/index.ts']`) but `buildStart` only handled object inputs (`{ index: 'src/index.ts' }`). When input is array, `inputAliasMap` stayed empty so emitted DTS chunks got `name: undefined` instead of smth like `index.d`.

**Fixed-string `entryFileNames` missing `.d` in output**

Vite 8 lib mode provides `entryFileNames` as function returning fixed string (like `'index.mjs'`) not a template with `[name]`. The `entryFileNames` hook converted `.mjs` to `.mts` but never inserted `.d`, producing `index.mts` instead of `index.d.mts`. Then `renderChunk` did not recognize it as a DTS file and skipped the fake-js reversal.

## fix

- Added `else` branch in `buildStart` to populate `inputAliasMap` for array inputs deriving chunk names from file basenames
- Added `filename_js_to_dts()` step in `entryFileNames` hook — same pattern that `fake-js` plugin already uses in its `chunkFileNames` hook

All 201 tests pass (195 existing + 6 new ones covering these cases).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
