### PR TITLE
fix: handle function overloads in .d.ts bundling

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -45,12 +45,27 @@ type TypeParams = Array<{
   typeParams: t.Identifier[]
 }>
 
+interface OverloadInfo {
+  decl: t.Declaration
+  params: TypeParams
+  deps: Dep[]
+  children: t.Node[]
+  depsOffset: number
+  paramsOffset: number
+  childrenOffset: number
+}
+
 interface DeclarationInfo {
   decl: t.Declaration
   bindings: t.Identifier[]
   params: TypeParams
   deps: Dep[]
   children: t.Node[]
+  overloads?: OverloadInfo[]
+  /** Number of deps/params/children belonging to the primary declaration (before merging overloads) */
+  primaryDepsCount?: number
+  primaryParamsCount?: number
+  primaryChildrenCount?: number
 }
 
 type NamespaceMap = Map<
@@ -159,6 +174,9 @@ export function createFakeJsPlugin({
 
     const appendStmts: t.Statement[] = []
     const namespaceStmts: NamespaceMap = new Map()
+    // Track binding names to their declaration IDs for function overload merging
+    const bindingToDeclarationId = new Map<string, number>()
+    const stmtsToRemove = new Set<number>()
 
     for (const [i, stmt] of program.body.entries()) {
       const setStmt = (stmt: t.Statement) => (program.body[i] = stmt)
@@ -258,6 +276,38 @@ export function createFakeJsPlugin({
         decl.leadingComments = stmt.leadingComments
       }
 
+      // Handle function overloads: merge into existing declaration
+      if (
+        decl.type === 'TSDeclareFunction' &&
+        bindings.length === 1 &&
+        bindingToDeclarationId.has(bindings[0].name)
+      ) {
+        const existingId = bindingToDeclarationId.get(bindings[0].name)!
+        const existing = getDeclaration(existingId)
+        if (!existing.overloads) {
+          existing.overloads = []
+          existing.primaryDepsCount = existing.deps.length
+          existing.primaryParamsCount = existing.params.length
+          existing.primaryChildrenCount = existing.children.length
+        }
+        existing.overloads.push({
+          decl,
+          params,
+          deps,
+          children,
+          depsOffset: existing.deps.length,
+          paramsOffset: existing.params.length,
+          childrenOffset: existing.children.length,
+        })
+        // Merge deps, params, and children into the primary so they go through
+        // Rolldown's identifier renaming pipeline
+        existing.deps.push(...deps)
+        existing.params.push(...params)
+        existing.children.push(...children)
+        stmtsToRemove.add(i)
+        continue
+      }
+
       const declarationId = registerDeclaration({
         decl,
         deps,
@@ -265,6 +315,11 @@ export function createFakeJsPlugin({
         params,
         children,
       })
+
+      // Track binding name for potential overload merging
+      if (decl.type === 'TSDeclareFunction' && bindings.length === 1) {
+        bindingToDeclarationId.set(bindings[0].name, declarationId)
+      }
 
       const declarationIdNode = t.numericLiteral(declarationId)
       const depsNode = t.arrowFunctionExpression(
@@ -340,7 +395,7 @@ export function createFakeJsPlugin({
 
     program.body = [
       ...Array.from(namespaceStmts.values()).map(({ stmt }) => stmt),
-      ...program.body,
+      ...program.body.filter((_, idx) => !stmtsToRemove.has(idx)),
       ...appendStmts,
     ]
 
@@ -378,19 +433,18 @@ export function createFakeJsPlugin({
     program.body = patchReExport(program.body)
 
     program.body = program.body
-      .map((node) => {
-        if (isHelperImport(node)) return null
-        if (node.type === 'ExpressionStatement') return null
+      .flatMap((node) => {
+        if (isHelperImport(node)) return []
+        if (node.type === 'ExpressionStatement') return []
 
         const newNode = patchImportExport(node, typeOnlyIds, cjsDefault)
-        if (newNode || newNode === false) {
-          return newNode
-        }
+        if (newNode === false) return []
+        if (newNode) return [newNode]
 
-        if (node.type !== 'VariableDeclaration') return node
+        if (node.type !== 'VariableDeclaration') return [node]
 
         if (!isRuntimeBindingVariableDeclaration(node)) {
-          return null
+          return []
         }
 
         const [declarationIdNode, depsFn, children /*, ignore sideEffect */] =
@@ -416,16 +470,23 @@ export function createFakeJsPlugin({
           overwriteNode(declaration.bindings[i], transformedBinding)
         }
 
-        for (const [i, child] of (
-          children.elements as t.StringLiteral[]
-        ).entries()) {
+        const primaryChildrenCount =
+          declaration.primaryChildrenCount ?? declaration.children.length
+        const primaryParamsCount =
+          declaration.primaryParamsCount ?? declaration.params.length
+        const primaryDepsCount =
+          declaration.primaryDepsCount ?? declaration.deps.length
+
+        for (let i = 0; i < primaryChildrenCount; i++) {
+          const child = (children.elements as t.StringLiteral[])[i]
           Object.assign(declaration.children[i], {
             loc: child.loc,
           })
         }
 
         const transformedParams = depsFn.params as t.Identifier[]
-        for (const [i, transformedParam] of transformedParams.entries()) {
+        for (let i = 0; i < primaryParamsCount; i++) {
+          const transformedParam = transformedParams[i]
           const transformedName = transformedParam.name
           for (const originalTypeParam of declaration.params[i].typeParams) {
             originalTypeParam.name = transformedName
@@ -434,7 +495,8 @@ export function createFakeJsPlugin({
 
         const transformedDeps = (depsFn.body as t.ArrayExpression)
           .elements as t.Expression[]
-        for (const [i, originalDep] of declaration.deps.entries()) {
+        for (let i = 0; i < primaryDepsCount; i++) {
+          const originalDep = declaration.deps[i]
           let transformedDep = transformedDeps[i]
           if (
             transformedDep.type === 'UnaryExpression' &&
@@ -457,9 +519,75 @@ export function createFakeJsPlugin({
           }
         }
 
-        return inheritNodeComments(node, declaration.decl)
+        // Restore overloaded declarations before the primary declaration
+        const overloadDecls: t.Statement[] = []
+        if (declaration.overloads) {
+          for (const overload of declaration.overloads) {
+            walkAST<t.Node | t.Comment>(overload.decl, {
+              enter(node) {
+                if (node.type === 'CommentBlock') return
+                delete node.loc
+              },
+            })
+            // Use the transformed binding name from the primary declaration
+            if ('id' in overload.decl && overload.decl.id) {
+              overwriteNode(overload.decl.id, { ...declaration.bindings[0] })
+            }
+
+            // Patch overload children locations from the merged children array
+            for (const [i, child] of overload.children.entries()) {
+              const mergedChild = (children.elements as t.StringLiteral[])[
+                overload.childrenOffset + i
+              ]
+              if (mergedChild) {
+                Object.assign(child, { loc: mergedChild.loc })
+              }
+            }
+
+            // Patch overload type params from the merged params array
+            for (const [i, param] of overload.params.entries()) {
+              const mergedParam = transformedParams[overload.paramsOffset + i]
+              if (mergedParam) {
+                for (const typeParam of param.typeParams) {
+                  typeParam.name = mergedParam.name
+                }
+              }
+            }
+
+            // Patch overload deps from the merged deps array
+            for (const [i, originalDep] of overload.deps.entries()) {
+              let transformedDep = transformedDeps[overload.depsOffset + i]
+              if (!transformedDep) continue
+              if (
+                transformedDep.type === 'UnaryExpression' &&
+                transformedDep.operator === 'void'
+              ) {
+                transformedDep = {
+                  ...t.identifier('undefined'),
+                  loc: transformedDep.loc,
+                  start: transformedDep.start,
+                  end: transformedDep.end,
+                }
+              } else if (isInfer(transformedDep)) {
+                transformedDep.name = '__Infer'
+              }
+
+              if (originalDep.replace) {
+                originalDep.replace(transformedDep)
+              } else {
+                Object.assign(originalDep, transformedDep)
+              }
+            }
+
+            overloadDecls.push(overload.decl as t.Statement)
+          }
+        }
+
+        return [
+          inheritNodeComments(node, declaration.decl),
+          ...overloadDecls,
+        ]
       })
-      .filter((node) => !!node)
 
     if (program.body.length === 0) {
       return 'export { };'

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -326,6 +326,19 @@ import { n as input2, t as Input2 } from "./chunks/CmCTH2kN.js";
 export { Input2, input2 };"
 `;
 
+exports[`function overloads 1`] = `
+"// function-overloads.d.ts
+//#region tests/fixtures/function-overloads.d.ts
+interface Config {
+  name: string;
+  version: number;
+}
+declare function useConfig(): Config;
+declare function useConfig<T>(selector: (config: Config) => T): T;
+//#endregion
+export { useConfig };"
+`;
+
 exports[`infer false branch 1`] = `
 "// index.d.ts
 //#region tests/fixtures/infer-false-branch/mod.d.ts

--- a/tests/fixtures/function-overloads.ts
+++ b/tests/fixtures/function-overloads.ts
@@ -1,0 +1,11 @@
+interface Config {
+  name: string
+  version: number
+}
+
+export function useConfig(): Config
+export function useConfig<T>(selector: (config: Config) => T): T
+export function useConfig<T>(selector?: (config: Config) => T) {
+  const config: Config = { name: 'app', version: 1 }
+  return selector ? selector(config) : config
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -599,3 +599,14 @@ test('decorators', async () => {
   )
   expect(snapshot).toMatchSnapshot()
 })
+
+// https://github.com/sxzz/rolldown-plugin-dts/issues/209
+test('function overloads', async () => {
+  const { snapshot } = await rolldownBuild(
+    path.resolve(dirname, 'fixtures/function-overloads.ts'),
+    [dts({ emitDtsOnly: true })],
+  )
+  expect(snapshot).toMatchSnapshot()
+  expect(snapshot).toContain('declare function useConfig(): Config')
+  expect(snapshot).toContain('declare function useConfig<T>')
+})


### PR DESCRIPTION
# fix: handle function overloads in `.d.ts` bundling

Fixes #209

## Problem

When `isolatedDeclarations` is not enabled, `rolldown-plugin-dts` uses `tsc` to generate `.d.ts` files. For function overloads, `tsc` correctly emits multiple `export declare function` declarations with the same name:

```ts
export declare function useConfig(): Config;
export declare function useConfig<T>(selector: (config: Config) => T): T;
```

During the `transform` phase, the fake-js plugin converts each declaration into a `var useConfig = [id, deps, children]` assignment. With overloads, this produces two `export var useConfig` statements, which Rolldown's parser rejects as duplicate exports.

## Solution

The fake-js plugin now detects function overload signatures during `transform` and merges them into the primary declaration:

- **Transform phase**: When a `TSDeclareFunction` is encountered whose binding name has already been processed, the overload's declaration, deps, params, and children are stored on the existing `DeclarationInfo` rather than emitting a new runtime variable. The overload's deps/params/children are appended to the primary's arrays so they go through Rolldown's identifier renaming pipeline.

- **RenderChunk phase**: When restoring a declaration that has overloads, all overload signatures are emitted alongside the primary declaration in original source order, with proper identifier renaming applied via the merged arrays.

## Test

Added a `function-overloads` test fixture that verifies both overload signatures appear in the bundled output:

```ts
interface Config {
  name: string
  version: number
}

export function useConfig(): Config
export function useConfig<T>(selector: (config: Config) => T): T
export function useConfig<T>(selector?: (config: Config) => T) {
  const config: Config = { name: 'app', version: 1 }
  return selector ? selector(config) : config
}
```