### PR TITLE
fix: preserve `type` modifier for `export type *` re-exports

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -70,6 +70,8 @@ export function createFakeJsPlugin({
   const declarationMap = new Map<number /* declaration id */, DeclarationInfo>()
   const commentsMap = new Map<string /* filename */, t.Comment[]>()
   const typeOnlyMap = new Map<string /* filename */, string[]>()
+  const typeOnlyStarSources = new Set<string>()
+  const moduleExportBindings = new Map<string, string[]>()
 
   return {
     name: 'rolldown-plugin-dts:fake-js',
@@ -137,11 +139,11 @@ export function createFakeJsPlugin({
     },
   }
 
-  function transform(
+  async function transform(
     this: TransformPluginContext,
     code: string,
     id: string,
-  ): TransformResult {
+  ): Promise<TransformResult> {
     let file: ParseResult
     try {
       file = parse(code, {
@@ -161,6 +163,20 @@ export function createFakeJsPlugin({
     const typeOnlyIds: string[] = []
     const identifierMap: Record<string, number> = Object.create(null)
 
+    // Pre-scan: resolve sources for `export type *` before
+    // rewriteImportExport strips the type modifier.
+    for (const stmt of program.body) {
+      if (
+        stmt.type === 'ExportAllDeclaration' &&
+        stmt.exportKind === 'type'
+      ) {
+        const resolved = await this.resolve(stmt.source.value, id)
+        if (resolved && !resolved.external) {
+          typeOnlyStarSources.add(resolved.id)
+        }
+      }
+    }
+
     if (comments) {
       const directives = collectReferenceDirectives(comments)
       commentsMap.set(id, directives)
@@ -168,6 +184,7 @@ export function createFakeJsPlugin({
 
     const appendStmts: t.Statement[] = []
     const namespaceStmts: NamespaceMap = new Map()
+    const exportedBindingNames: string[] = []
 
     for (const [i, stmt] of program.body.entries()) {
       const setStmt = (stmt: t.Statement) => (program.body[i] = stmt)
@@ -248,6 +265,12 @@ export function createFakeJsPlugin({
         bindings.push(binding)
         // @ts-expect-error
         decl.id = binding
+      }
+
+      if (isExportDecl) {
+        for (const binding of bindings) {
+          exportedBindingNames.push(binding.name)
+        }
       }
 
       const params: TypeParams = collectParams(decl)
@@ -354,6 +377,7 @@ export function createFakeJsPlugin({
     ]
 
     typeOnlyMap.set(id, typeOnlyIds)
+    moduleExportBindings.set(id, exportedBindingNames)
 
     const result = generate(file, {
       comments: false,
@@ -376,6 +400,11 @@ export function createFakeJsPlugin({
     for (const module of chunk.moduleIds) {
       const ids = typeOnlyMap.get(module)
       if (ids) typeOnlyIds.push(...ids)
+
+      if (typeOnlyStarSources.has(module)) {
+        const names = moduleExportBindings.get(module)
+        if (names) typeOnlyIds.push(...names)
+      }
     }
 
     let file: ParseResult

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -457,7 +457,7 @@ exports[`resolve dts 1`] = `
 //#region tests/fixtures/resolve-dts/mod.d.ts
 type Foo = string;
 //#endregion
-export { Foo };
+export { type Foo };
 // index.js
 "
 `;
@@ -571,5 +571,5 @@ declare const ns = 42;
 //#region tests/fixtures/type-only-export/all.d.ts
 declare const all = 42;
 //#endregion
-export { A as RuntimeA, type A as TypeA, A as TypeC, type B as TypeB, all, type namespace_d_exports as ns };"
+export { A as RuntimeA, type A as TypeA, A as TypeC, type B as TypeB, type all, type namespace_d_exports as ns };"
 `;

--- a/tests/rollup-plugin-dts/export-all-as-type/snapshot.d.ts
+++ b/tests/rollup-plugin-dts/export-all-as-type/snapshot.d.ts
@@ -2,4 +2,4 @@
 //#region tests/rollup-plugin-dts/export-all-as-type/all.d.ts
 declare const foo: number;
 //#endregion
-export { foo };
+export { type foo };


### PR DESCRIPTION
## Problem

`export type * from './mod'` loses the `type` modifier during bundling, producing incorrect `.d.ts` output where re-exported names appear as value exports instead of type-only exports.

For example, given:
```ts
export type * from './all'
```
where `./all` exports `const all = 42`, the bundled output was:
```ts
export { all };
```
instead of the correct:
```ts
export { type all };
```

This only affected the bare `export type *` form — the namespace form (`export type * as ns from`) already worked because Babel parses it as `ExportNamedDeclaration` with `ExportNamespaceSpecifier`, which goes through the existing type-only tracking path.

## Root Cause

In `rewriteImportExport()`, `ExportAllDeclaration` nodes had their `exportKind` unconditionally set to `'value'` so Rolldown can process them as JavaScript. But unlike `ExportNamedDeclaration` (which has specifiers whose names get tracked in `typeOnlyIds`), `ExportAllDeclaration` has no specifiers — so there was nothing to track, and the type-only information was silently discarded.

## Fix

1. **Pre-scan** the AST before `rewriteImportExport` runs, resolving source modules of `export type *` declarations and recording them in a `typeOnlyStarSources` set.
2. **Track exported binding names** per module during transform in `moduleExportBindings`.
3. **In `renderChunk`**, for any source module that was a target of `export type *`, add all of its exported bindings to `typeOnlyIds` so `patchImportExport` correctly restores the `type` modifier.

## Related

- Closes #95
- Relevant to ng-packagr/ng-packagr#3268 (this is one of the blocking bugs for adopting rolldown-plugin-dts)
- PR #175 and PR #191 also make `transform` async — there will be positional merge conflicts with whichever lands second, but no semantic overlap

## Test plan

- Existing `type-only-export` fixture now correctly outputs `type all` (snapshot updated)
- Existing `resolve-dts` fixture now correctly outputs `type Foo` (snapshot updated)
- `rollup-plugin-dts/export-all-as-type` compatibility test now correctly outputs `type foo` (snapshot updated)
- Full test suite passes (196 passed, 1 expected fail)