### PR TITLE
docs: expand JSDoc coverage across the public API

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -84,6 +84,33 @@ type NamespaceMap = Map<
   }
 >
 
+/**
+ * Creates the Rolldown {@linkcode Plugin | plugin} that lets `.d.ts` files be
+ * bundled as if they were JavaScript. Rolldown cannot rename or tree-shake
+ * TypeScript declarations directly, so `transform` rewrites every declaration
+ * in a `.d.ts` module into a placeholder JavaScript binding whose array holds
+ * the declaration's dependencies:
+ *
+ * ```ts
+ * // export declare function x(xx: X): void
+ * var [x] = [0, () => [X]];
+ * ```
+ *
+ * Rolldown then bundles those bindings as ordinary JavaScript, renaming them to
+ * resolve collisions (`x` -> `x$1`). `renderChunk` swaps each binding back for
+ * its original declaration, applying the names Rolldown chose:
+ *
+ * ```ts
+ * export declare function x$1(xx: X$1): void;
+ * ```
+ *
+ * `dts()` always includes this plugin, and passes it options already normalized
+ * by `resolveOptions()`. Reach for it directly only when assembling the
+ * plugin pipeline by hand.
+ *
+ * @returns A Rolldown {@linkcode Plugin | plugin} named `rolldown-plugin-dts:fake-js`.
+ * @throws An {@linkcode Error} during `outputOptions` if the output format is `cjs`, which cannot represent bundled `.d.ts` output.
+ */
 export function createFakeJsPlugin({
   sourcemap,
   cjsDefault,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -46,6 +46,14 @@ export interface TsModule {
 /** dts filename -> ts module */
 export type DtsMap = Map<string, TsModule>
 
+/**
+ * Creates the Rolldown {@linkcode Plugin | plugin} responsible for generating
+ * `.d.ts` declaration files from source modules. Depending on the resolved
+ * options it delegates to Oxc isolated declarations, `tsgo`, or the
+ * TypeScript compiler.
+ *
+ * @returns A Rolldown {@linkcode Plugin | plugin} that registers the `transform` and `load` hooks needed for `.d.ts` generation.
+ */
 export function createGeneratePlugin({
   generator,
   entry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,41 @@ import type { Plugin } from 'rolldown'
 
 const debug = createDebug('rolldown-plugin-dts:options')
 
+/**
+ * Creates a set of Rolldown {@linkcode Plugin | plugins} that generate and
+ * bundle `.d.ts` declaration files alongside your source build.
+ *
+ * @param [options] - Configuration {@linkcode Options | options} for the plugin.
+ * @returns An array of Rolldown {@linkcode Plugin | plugins} to include in your config.
+ *
+ * @example
+ * <caption>Basic usage in `rolldown.config.ts`</caption>
+ *
+ * ```ts
+ * import { defineConfig } from 'rolldown';
+ * import { dts } from 'rolldown-plugin-dts';
+ *
+ * export default defineConfig({
+ *   input: './src/index.ts',
+ *   plugins: [dts()],
+ *   output: [{ dir: 'dist', format: 'es' }],
+ * });
+ * ```
+ *
+ * @example
+ * <caption>Emit DTS only for a separate CommonJS build</caption>
+ *
+ * ```ts
+ * import { defineConfig } from 'rolldown';
+ * import { dts } from 'rolldown-plugin-dts';
+ *
+ * export default defineConfig({
+ *   input: './src/index.ts',
+ *   plugins: [dts({ emitDtsOnly: true })],
+ *   output: [{ dir: 'dist', format: 'cjs' }],
+ * });
+ * ```
+ */
 export function dts(options: Options = {}): Plugin[] {
   debug('resolving dts options')
   const resolved = resolveOptions(options)

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,10 +11,16 @@ import { requireTS } from './tsc/load-tsc.ts'
 import { getVueVolarPlugin } from './tsc/vue.ts'
 import { isTS70Installed } from './tsgo.ts'
 import { VolarContext, type VolarPlugin } from './volar.ts'
+import type { invalidateContextFile } from './tsc/context.ts'
 import type { IsolatedDeclarationsOptions } from 'rolldown/experimental'
 
 const debug = createDebug('rolldown-plugin-dts:options')
 
+/**
+ * The subset of the `console` API the plugin uses for diagnostics. Pass a
+ * custom implementation to route the plugin's output through your build tool's
+ * logger.
+ */
 export interface Logger {
   info: (...args: any[]) => void
   warn: (...args: any[]) => void
@@ -22,6 +28,10 @@ export interface Logger {
 }
 
 //#region General Options
+/**
+ * Options that apply across all DTS generation modes (`oxc`, `tsc`, and
+ * `tsgo`).
+ */
 export interface GeneralOptions {
   /**
    * The generator used to produce `.d.ts` files.
@@ -46,70 +56,120 @@ export interface GeneralOptions {
   generator?: 'tsc' | 'oxc' | 'tsgo'
 
   /**
-   * Glob pattern(s) to filter which entry files get `.d.ts` generation.
-   *
-   * When specified, only entry files matching these patterns will emit `.d.ts` chunks.
-   * When not specified, all entries get `.d.ts` generation.
-   *
-   * Supports negation patterns (e.g., `['**', '!src/icons/**']`) for exclusion.
-   * Patterns are matched against file paths relative to `cwd`.
+   * Glob pattern(s) to filter which files get `.d.ts` generation. When
+   * specified, only files matching these patterns will emit `.d.ts` chunks
+   * even if they are not Rolldown entry points. Patterns filter modules
+   * already present in Rolldown's build graph (the `input` plus everything
+   * it imports); they do not glob the filesystem to pull in new files. When
+   * not specified, all entries get `.d.ts` generation. Supports negation
+   * patterns (e.g., `['**', '!src/icons/**']`) for exclusion. Patterns are
+   * matched against file paths relative to
+   * {@linkcode GeneralOptions.cwd | cwd}.
    *
    * @example
-   * entry: 'src/index.ts'
-   * entry: ['src/*.ts', '!src/internal/**']
+   * <caption>Include a single entry file</caption>
+   *
+   * ```ts
+   * import { defineConfig } from 'rolldown';
+   * import { dts } from 'rolldown-plugin-dts';
+   *
+   * export default defineConfig({
+   *   plugins: [
+   *     dts({
+   *       entry: 'src/index.ts',
+   *     }),
+   *   ],
+   * });
+   * ```
+   *
+   * @example
+   * <caption>Include all `.ts` files in `src` except those in `src/internal`</caption>
+   *
+   * ```ts
+   * import { defineConfig } from 'rolldown';
+   * import { dts } from 'rolldown-plugin-dts';
+   *
+   * export default defineConfig({
+   *   plugins: [
+   *     dts({
+   *       entry: ['src/*.ts', '!src/internal/‎**'],
+   *     }),
+   *   ],
+   * });
+   * ```
    */
   entry?: string | string[]
 
   /**
-   * The directory in which the plugin will search for the `tsconfig.json` file.
+   * The directory in which the plugin will search for the
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * file.
+   *
+   * @default process.cwd()
    */
   cwd?: string
 
   /**
    * Set to `true` if your entry files are `.d.ts` files instead of `.ts` files.
+   * When enabled, the plugin will skip generating a `.d.ts` file for the
+   * entry point.
    *
-   * When enabled, the plugin will skip generating a `.d.ts` file for the entry point.
+   * @default false
    */
   dtsInput?: boolean
 
   /**
-   * If `true`, the plugin will emit only `.d.ts` files and remove all other output chunks.
+   * If `true`, the plugin will emit only `.d.ts` files and remove all other
+   * output chunks. This is especially useful when generating `.d.ts` files for
+   * the CommonJS format as part of a separate build step.
    *
-   * This is especially useful when generating `.d.ts` files for the CommonJS format as part of a separate build step.
+   * @default false
    */
   emitDtsOnly?: boolean
 
   /**
-   * The path to the `tsconfig.json` file.
+   * Configures TypeScript configuration file resolution and usage.
+   * - **`true`**: The plugin walks up from {@linkcode GeneralOptions.cwd | cwd} via {@linkcode https://github.com/privatenumber/get-tsconfig | get-tsconfig} to locate the nearest {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}. If none is found, no tsconfig is loaded.
+   * - **`false`**: The plugin will ignore any {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json} file. You can still specify {@linkcode GeneralOptions.compilerOptions | compilerOptions} directly in the options.
+   * - **`string`**: Path to a specific {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json} file to use. It can be an absolute path or a path relative to the {@linkcode GeneralOptions.cwd | cwd}.
    *
-   * If set to `false`, the plugin will ignore any `tsconfig.json` file.
-   * You can still specify `compilerOptions` directly in the options.
-   *
-   * @default 'tsconfig.json'
+   * @default true
    */
   tsconfig?: string | boolean
 
   /**
-   * Pass a raw `tsconfig.json` object directly to the plugin.
+   * Pass a raw {@linkcode https://www.typescriptlang.org/tsconfig | tsconfig}
+   * object directly to the plugin.
    *
-   * @see https://www.typescriptlang.org/tsconfig
+   * @default {}
+   * @see {@link https://www.typescriptlang.org/tsconfig | TypeScript `tsconfig` documentation}
    */
   tsconfigRaw?: Omit<TsconfigJson, 'compilerOptions'>
 
   /**
-   * Override the `compilerOptions` specified in `tsconfig.json`.
+   * Override the
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#compilerOptions | compilerOptions}
+   * specified in
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}.
    *
-   * @see https://www.typescriptlang.org/tsconfig/#compilerOptions
+   * @default {}
+   * @see {@linkcode https://www.typescriptlang.org/tsconfig/#compilerOptions | compilerOptions}
    */
   compilerOptions?: TsconfigJson.CompilerOptions
 
   /**
-   * If `true`, the plugin will generate declaration maps (`.d.ts.map`) for `.d.ts` files.
+   * If `true`, the plugin will generate declaration maps (`.d.ts.map`) for
+   * `.d.ts` files. If this option is not specified, it will fallback to the
+   * value of
+   * {@linkcode https://www.typescriptlang.org/tsconfig#declarationMap | declarationMap}.
+   *
+   * @default false
    */
   sourcemap?: boolean
 
   /**
-   * Specifies a resolver to resolve type definitions, especially for `node_modules`.
+   * Specifies a resolver to resolve type definitions, especially for
+   * `node_modules`.
    *
    * - `'oxc'`: Uses Oxc's module resolution, which is faster and more efficient.
    * - `'tsc'`: Uses TypeScript's native module resolution, which may be more compatible with complex setups, but slower.
@@ -119,13 +179,32 @@ export interface GeneralOptions {
   resolver?: 'oxc' | 'tsc'
 
   /**
-   * Determines how the default export is emitted.
-   *
-   * If set to `true`, and you are only exporting a single item using `export default ...`,
-   * the output will use `export = ...` instead of the standard ES module syntax.
-   * This is useful for compatibility with CommonJS.
+   * Determines how the `default` export is emitted. If set to `true`, and you
+   * are only exporting a single item using
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/2/modules.html#es-module-syntax | export default},
+   * the output will use
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require | export =}
+   * instead of the standard ES module syntax. This is useful for compatibility
+   * with
+   * {@link https://nodejs.org/api/modules.html#modules-commonjs-modules | CommonJS}.
    * This only controls the output format and does not enable support for
    * CommonJS-style `.d.ts` input.
+   *
+   * @default false
+   *
+   * @example
+   * <caption>With `cjsDefault: true`</caption>
+   *
+   * ```ts
+   * export default function foo(): void {}
+   * ```
+   *
+   * will generate
+   *
+   * ```ts
+   * declare function foo(): void;
+   * export = foo;
+   * ```
    */
   cjsDefault?: boolean
 
@@ -138,127 +217,213 @@ export interface GeneralOptions {
    */
   sideEffects?: boolean
 
+  /**
+   * The {@linkcode Logger} used to report warnings and progress.
+   *
+   * @default globalThis.console
+   */
   logger?: Logger
 }
 
 //#region tsc Options
+/**
+ * Options specific to TypeScript compiler (`tsc`) based DTS generation. These
+ * options are only used when the `tsc` generator is selected; they are ignored
+ * when {@linkcode Options.oxc | oxc} or {@linkcode Options.tsgo | tsgo} picks a
+ * different {@linkcode GeneralOptions.generator | generator}.
+ */
 export interface TscOptions {
   /**
    * Build mode for the TypeScript compiler:
-   *
-   * - If `true`, the plugin will use [`tsc -b`](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript) to build the project and all referenced projects before emitting `.d.ts` files.
-   * - If `false`, the plugin will use [`tsc`](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to emit `.d.ts` files without building referenced projects.
+   * - If `true`, the plugin will use {@linkcode https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript | tsc -b} to build the project and all referenced projects before emitting `.d.ts` files.
+   * - If `false`, the plugin will use {@linkcode https://www.typescriptlang.org/docs/handbook/compiler-options.html | tsc} to emit `.d.ts` files without building referenced projects.
    *
    * @default false
    */
   build?: boolean
 
   /**
-   * If your tsconfig.json has
-   * [`references`](https://www.typescriptlang.org/tsconfig/#references) option,
-   * `rolldown-plugin-dts` will use [`tsc
-   * -b`](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript)
+   * If your
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * has
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#references | references}
+   * option, `rolldown-plugin-dts` will use
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript | tsc -b}
    * to build the project and all referenced projects before emitting `.d.ts`
-   * files.
+   * files. In such case, if this option is `true`, `rolldown-plugin-dts` will
+   * write down all built files into your disk, including
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile | .tsbuildinfo}
+   * and other built files. This is equivalent to running
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript | tsc -b}
+   * in your project. Otherwise, if this option is `false`,
+   * `rolldown-plugin-dts` will write built files only into memory and leave a
+   * small footprint in your disk. Enabling this option will decrease the build
+   * time by caching previous build results. This is helpful when you have a
+   * large project with multiple referenced projects. By default, this is
+   * `true` if your
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * has
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#incremental | incremental}
+   * or
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile | tsBuildInfoFile}
+   * enabled. This option is only used when both {@linkcode Options.oxc | oxc}
+   * and {@linkcode Options.tsgo | tsgo} are `false`.
    *
-   * In such case, if this option is `true`, `rolldown-plugin-dts` will write
-   * down all built files into your disk, including
-   * [`.tsbuildinfo`](https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile)
-   * and other built files. This is equivalent to running `tsc -b` in your
-   * project.
-   *
-   * Otherwise, if this option is `false`, `rolldown-plugin-dts` will write
-   * built files only into memory and leave a small footprint in your disk.
-   *
-   * Enabling this option will decrease the build time by caching previous build
-   * results. This is helpful when you have a large project with multiple
-   * referenced projects.
-   *
-   * By default, `incremental` is `true` if your tsconfig has
-   * [`incremental`](https://www.typescriptlang.org/tsconfig/#incremental) or
-   * [`tsBuildInfoFile`](https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile)
-   * enabled.
-   *
-   * This option is only used when {@link Options.oxc} is
-   * `false`.
+   * @default false
    */
   incremental?: boolean
 
   /**
-   * If `true`, the plugin will generate `.d.ts` files using `vue-tsc`.
+   * If `true`, the plugin will generate `.d.ts` files using
+   * {@linkcode https://github.com/vuejs/language-tools/tree/HEAD/packages/tsc | vue-tsc}.
+   *
+   * @default false
    */
   vue?: boolean
 
   /**
-   * If `true`, the plugin will launch a separate process for `tsc` or `vue-tsc`.
+   * If `true`, the plugin will launch a separate process for
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/compiler-options.html | tsc}
+   * or
+   * {@linkcode https://github.com/vuejs/language-tools/tree/HEAD/packages/tsc | vue-tsc}.
    * This enables processing multiple projects in parallel.
+   *
+   * @default false
    */
   parallel?: boolean
 
   /**
-   * If `true`, the plugin will prepare all files listed in `tsconfig.json` for `tsc` or `vue-tsc`.
+   * If `true`, the plugin will prepare all files listed in
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * for
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/compiler-options.html | tsc}
+   * or
+   * {@linkcode https://github.com/vuejs/language-tools/tree/HEAD/packages/tsc | vue-tsc}.
+   * This is especially useful when you have a single
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * for multiple projects in a monorepo.
    *
-   * This is especially useful when you have a single `tsconfig.json` for multiple projects in a monorepo.
+   * @default false
    */
   eager?: boolean
 
   /**
    * If `true`, the plugin will create a new isolated context for each build,
    * ensuring that previously generated `.d.ts` code and caches are not reused.
-   *
-   * By default, the plugin may reuse internal caches or incremental build artifacts
-   * to speed up repeated builds. Enabling this option forces a clean context,
-   * guaranteeing that all type definitions are generated from scratch.
+   * By default, the plugin may reuse internal caches or incremental build
+   * artifacts to speed up repeated builds. Enabling this option forces a clean
+   * context, guaranteeing that all type definitions are generated from
+   * scratch. Use {@linkcode invalidateContextFile} to selectively clear
+   * individual files from the context rather than forcing a full rebuild on
+   * every build.
    *
    * @default false
+   *
+   * @example
+   * <caption>Invalidate a specific file in the context between builds</caption>
+   *
+   * ```ts
+   * import {
+   *   globalContext,
+   *   invalidateContextFile,
+   * } from 'rolldown-plugin-dts/tsc-context';
+   *
+   * invalidateContextFile(globalContext, 'src/foo.ts');
+   * ```
    */
   newContext?: boolean
 
   /**
    * If `true`, the plugin will emit `.d.ts` files for `.js` files as well.
-   * This is useful when you want to generate type definitions for JavaScript files with JSDoc comments.
-   *
-   * Enabled by default when `allowJs` in compilerOptions is `true`.
-   * This option is only used when {@link Options.oxc} is
+   * This is useful when you want to generate type definitions for JavaScript
+   * files with JSDoc comments. When not specified, this option defaults to
+   * `true` if either
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#checkJs | checkJs} or
+   * {@linkcode https://www.typescriptlang.org/tsconfig/#allowJs | allowJs} is
+   * enabled. This option is only used when {@linkcode Options.oxc | oxc} is
    * `false`.
+   *
+   * @default false
    */
   emitJs?: boolean
 }
 
+/**
+ * The full configuration interface for the `dts` plugin. Combines
+ * {@linkcode GeneralOptions} and {@linkcode TscOptions} and adds the
+ * {@linkcode Options.oxc | oxc} and {@linkcode Options.tsgo | tsgo} options.
+ */
 export interface Options extends GeneralOptions, TscOptions {
   //#region Oxc
 
   /**
-   * If `true`, the plugin will generate `.d.ts` files using Oxc,
-   * which is significantly faster than the TypeScript compiler.
+   * If `true`, the plugin will generate `.d.ts` files using Oxc, which is
+   * significantly faster than the TypeScript compiler. The `oxc` generator is
+   * selected automatically when
+   * {@linkcode https://www.typescriptlang.org/tsconfig#isolatedDeclarations | isolatedDeclarations}
+   * is set to `true` in
+   * {@linkcode GeneralOptions.compilerOptions | compilerOptions}, unless
+   * {@linkcode GeneralOptions.generator | generator} is set explicitly, or
+   * {@linkcode Options.vue | vue} forces the `tsc` generator.
    *
-   * This option is automatically enabled when `isolatedDeclarations` in `compilerOptions` is set to `true`.
+   * @default false
    */
   oxc?: boolean | Omit<IsolatedDeclarationsOptions, 'sourcemap'>
 
   //#region TypeScript Go
 
   /**
-   * **[Experimental]** Enables DTS generation using `tsgo`.
+   * Enables DTS generation using
+   * {@linkcode https://github.com/microsoft/typescript-go | tsgo}. This is
+   * automatically enabled when the TypeScript Go compiler (v7+) is installed
+   * as the `typescript` package. Otherwise, make sure
+   * {@linkcode https://github.com/microsoft/typescript-go | @typescript/native-preview}
+   * is installed as a dependency, or provide a custom path to the `tsgo`
+   * binary using the {@linkcode TsgoOptions.path | path} option.
    *
-   * This is automatically enabled when the TypeScript Go compiler (v7+) is
-   * installed as the `typescript` package. Otherwise, make sure
-   * `@typescript/native-preview` is installed as a dependency, or provide a
-   * custom path to the `tsgo` binary using the `path` option.
+   * **Note:** TypeScript 7.0 does not yet have a stable API and is
+   * experimental. This option is not yet recommended for production
+   * environments, and some options (such as
+   * {@linkcode GeneralOptions.tsconfigRaw | tsconfigRaw} and
+   * {@linkcode https://www.typescriptlang.org/tsconfig#isolatedDeclarations | isolatedDeclarations})
+   * will be unavailable when it is enabled. Requires
+   * {@linkcode GeneralOptions.tsconfig | tsconfig} to resolve to a file.
    *
-   * **Note:** TypeScript 7.0 does not yet have a stable API and is experimental.
-   * This option is not yet recommended for production environments, and some
-   * options (such as `tsconfigRaw` and `isolatedDeclarations`) will be
-   * unavailable when it is enabled.
+   * @default false
    *
+   * @example
+   * <caption>Use `tsgo` from `@typescript/native-preview` dependency</caption>
    *
    * ```ts
-   * // Use tsgo from `@typescript/native-preview` dependency
-   * tsgo: true
+   * import { defineConfig } from 'rolldown';
+   * import { dts } from 'rolldown-plugin-dts';
    *
-   * // Use custom tsgo path (e.g., managed by Nix)
-   * tsgo: { path: '/path/to/tsgo' }
+   * export default defineConfig({
+   *   plugins: [
+   *     dts({
+   *       tsgo: true,
+   *     }),
+   *   ],
+   * });
    * ```
+   *
+   * @example
+   * <caption>Use custom `tsgo` path (e.g., managed by Nix)</caption>
+   *
+   * ```ts
+   * import { defineConfig } from 'rolldown';
+   * import { dts } from 'rolldown-plugin-dts';
+   *
+   * export default defineConfig({
+   *   plugins: [
+   *     dts({
+   *       tsgo: { path: '/path/to/tsgo' },
+   *     }),
+   *   ],
+   * });
+   * ```
+   *
+   * @experimental
    */
   tsgo?: boolean | TsgoOptions
 
@@ -268,6 +433,13 @@ export interface Options extends GeneralOptions, TscOptions {
   volarPlugin?: VolarPlugin
 }
 
+/**
+ * Options for the `tsgo` binary used when
+ * {@linkcode Options.tsgo | tsgo} is specified as an object rather than a
+ * `boolean`.
+ *
+ * @experimental
+ */
 export interface TsgoOptions {
   /**
    * Custom path to the `tsgo` binary.
@@ -277,6 +449,10 @@ export interface TsgoOptions {
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 
+/**
+ * The fully resolved and normalized form of {@linkcode Options} with all
+ * defaults applied. Returned by {@linkcode resolveOptions()}.
+ */
 export type OptionsResolved = Overwrite<
   Required<Omit<Options, 'compilerOptions' | 'vue' | 'volarPlugin'>>,
   {
@@ -291,6 +467,22 @@ export type OptionsResolved = Overwrite<
 
 let warnedTsgo = false
 
+/**
+ * Normalizes raw user {@linkcode Options} into {@linkcode OptionsResolved},
+ * applying defaults and deriving the values the plugins depend on: it locates
+ * and reads the {@linkcode GeneralOptions.tsconfig | tsconfig}, merges
+ * {@linkcode GeneralOptions.compilerOptions | compilerOptions} over it, picks
+ * the {@linkcode GeneralOptions.generator | generator}, and falls back to the
+ * tsconfig for {@linkcode GeneralOptions.sourcemap | sourcemap},
+ * {@linkcode TscOptions.incremental | incremental} and
+ * {@linkcode TscOptions.emitJs | emitJs} when they are not set. `dts()` calls
+ * this for you. Call it directly only when assembling the plugin pipeline by
+ * hand, since the exported plugin factories expect options that have already
+ * been resolved.
+ *
+ * @returns The resolved {@linkcode OptionsResolved | options}.
+ * @throws An {@linkcode Error} if {@linkcode TscOptions.vue | vue} is combined with {@linkcode Options.volarPlugin | volarPlugin}, if either is used while TypeScript 7.0 is installed, or if the `tsgo` generator is selected without a tsconfig.
+ */
 export function resolveOptions({
   generator,
   entry,

--- a/src/tsc/context.ts
+++ b/src/tsc/context.ts
@@ -1,27 +1,76 @@
 import path from 'node:path'
 import { createDebug } from 'obug'
+import type { Options } from '../options.ts'
 import type { ParsedCommandLine, Program } from 'typescript'
 
 const debug = createDebug('rolldown-plugin-dts:tsc-context')
 
-// A parsed tsconfig file with its path.
+/**
+ * A parsed `tsconfig` file with its path.
+ */
 export interface ParsedProject {
+  /**
+   * The path to the
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * file that was parsed. This is used as a key in the
+   * {@linkcode TscContext.projects | projects} map of the
+   * {@linkcode TscContext}.
+   */
   tsconfigPath: string
+
+  /**
+   * The parsed
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * file. This is used to create a {@linkcode Program | program} for the
+   * project.
+   */
   parsedConfig: ParsedCommandLine
 }
 
-// A map of a source file to the project it belongs to. This makes it faster to
-// find the project for a source file.
+/**
+ * A map of a source file to the {@linkcode ParsedProject | project} it belongs
+ * to. This makes it faster to find the project for a source file.
+ */
 export type SourceFileToProjectMap = Map<string, ParsedProject>
 
+/**
+ * The context for the TypeScript compiler. This is used to store the programs
+ * and files that have been processed by the plugin. This allows the plugin to
+ * reuse programs and files across multiple calls to `tscEmit`, which can
+ * improve performance when processing multiple files in the same project.
+ */
 export interface TscContext {
+  /**
+   * The list of {@linkcode Program | program}s that have been created by
+   * the plugin. Each {@linkcode Program | program} corresponds to a
+   * {@linkcode https://www.typescriptlang.org/docs/handbook/tsconfig-json.html | tsconfig.json}
+   * file that has been processed. The plugin will try to reuse existing
+   * programs when processing files, but if a file is not found in any existing
+   * {@linkcode Program | program}, a new {@linkcode Program | program}
+   * will be created for it.
+   */
   programs: Program[]
+
+  /**
+   * A map of file paths to their contents. This is used to store the contents
+   * of files that have been processed by the plugin. The key is the file path,
+   * and the value is the file contents.
+   */
   files: Map<string, string>
 
-  // A map of a root tsconfig to all projects referenced from it.
+  /**
+   * A map of a root `tsconfig` to all projects referenced from it.
+   */
   projects: Map<string, SourceFileToProjectMap>
 }
 
+/**
+ * Creates a new, empty {@linkcode TscContext}. Use this when
+ * {@linkcode Options.newContext | newContext} is `true` to get a fresh
+ * context for each build.
+ *
+ * @returns A new {@linkcode TscContext} with empty program, file, and project collections.
+ */
 export function createContext(): TscContext {
   const programs: Program[] = []
   const files = new Map<string, string>()
@@ -29,6 +78,27 @@ export function createContext(): TscContext {
   return { programs, files, projects }
 }
 
+/**
+ * Removes a single file from the given {@linkcode TscContext}, causing it to
+ * be reprocessed on the next build. This is a lighter alternative to
+ * {@linkcode Options.newContext | newContext}, which forces a full context
+ * reset on every build.
+ *
+ * @param context - The context to invalidate the file in.
+ * @param file - The path to the file to invalidate.
+ *
+ * @example
+ * <caption>Invalidating a single file in the context</caption>
+ *
+ * ```ts
+ * import {
+ *   globalContext,
+ *   invalidateContextFile,
+ * } from 'rolldown-plugin-dts/tsc-context';
+ *
+ * invalidateContextFile(globalContext, 'src/foo.ts');
+ * ```
+ */
 export function invalidateContextFile(context: TscContext, file: string): void {
   file = path.resolve(file).replaceAll('\\', '/')
   debug(`invalidating context file: ${file}`)
@@ -41,4 +111,9 @@ export function invalidateContextFile(context: TscContext, file: string): void {
   context.projects.clear()
 }
 
+/**
+ * The shared, module-level {@linkcode TscContext} used by default across all
+ * builds. Reused automatically unless
+ * {@linkcode Options.newContext | newContext} is `true`.
+ */
 export const globalContext: TscContext = createContext()

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -6,6 +6,14 @@ export type { TscModule, TscOptions, TscResult } from './types.ts'
 
 const debug = createDebug('rolldown-plugin-dts:tsc')
 
+/**
+ * Emits TypeScript declaration files for a single source file. Dispatches to
+ * {@linkcode tscEmitBuild()} when {@linkcode TscOptions.build | build} is
+ * `true`, otherwise uses {@linkcode tscEmitCompiler()}.
+ *
+ * @param tscOptions - The options for emitting the declaration file, including the path to the source file, project configuration, and whether to use {@linkcode https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript | tsc --build} mode.
+ * @returns A {@linkcode TscResult | result} with the generated {@linkcode TscResult.code | code}, {@linkcode TscResult.map | sourcemap}, or an {@linkcode TscResult.error | error message}.
+ */
 export function tscEmit(tscOptions: TscOptions): TscResult {
   debug(`running tscEmit ${tscOptions.id}`)
 

--- a/src/tsc/types.ts
+++ b/src/tsc/types.ts
@@ -4,8 +4,28 @@ import type { TsconfigJson } from 'get-tsconfig'
 import type { SourceMapInput } from 'rolldown'
 import type * as ts from 'typescript'
 
+/**
+ * Holds the TypeScript {@linkcode ts.Program | program} and
+ * {@linkcode ts.SourceFile | SourceFile} for a module being processed by the
+ * TypeScript compiler, cached inside a {@linkcode TscContext | context} to
+ * avoid re-parsing on every build.
+ */
 export interface TscModule {
+  /**
+   * The {@linkcode ts.Program | program} for the module. This is used to emit
+   * the TypeScript code for the module. The {@linkcode ts.Program | program}
+   * is created using the TypeScript compiler API and is set up with the
+   * necessary {@linkcode ts.CompilerOptions | compilerOptions} and
+   * {@linkcode ts.CompilerHost | host} for the module.
+   */
   program: ts.Program
+
+  /**
+   * The {@linkcode ts.SourceFile | SourceFile} for the module. This is the
+   * parsed representation of the source file, used to locate the specific
+   * file within the {@linkcode ts.Program | program} when emitting
+   * declarations.
+   */
   file: ts.SourceFile
 }
 
@@ -15,15 +35,49 @@ export interface TscOptions {
   cwd: string
   build: boolean
   incremental: boolean
+
+  /**
+   * Entry file paths passed to the TypeScript compiler to scope the program.
+   */
   entries?: string[]
+
+  /**
+   * The source file path being emitted in this invocation.
+   */
   id: string
   sourcemap: boolean
   volarContext?: VolarContext
+
+  /**
+   * The context for the TypeScript compiler. This is used to store the
+   * programs created by the compiler and other related information.
+   *
+   * @default globalContext
+   */
   context?: TscContext
 }
 
+/**
+ * The result of a TypeScript declaration emit operation. Exactly one of
+ * {@linkcode TscResult.code | code} or {@linkcode TscResult.error | error}
+ * will be defined: {@linkcode TscResult.code | code} when compilation
+ * succeeded, {@linkcode TscResult.error | error} when it failed.
+ * {@linkcode TscResult.map | map} is only present when sourcemaps are
+ * enabled and {@linkcode TscResult.code | code} is defined.
+ */
 export interface TscResult {
+  /**
+   * The generated `.d.ts` declaration code, if compilation succeeded.
+   */
   code?: string
+
+  /**
+   * The source map for the generated `.d.ts` file, if sourcemaps are enabled.
+   */
   map?: SourceMapInput
+
+  /**
+   * An error message string if the TypeScript compilation failed.
+   */
   error?: string
 }

--- a/src/tsc/worker.ts
+++ b/src/tsc/worker.ts
@@ -1,14 +1,41 @@
 import process from 'node:process'
 import { tscEmit, type TscOptions, type TscResult } from './index.ts'
 
+/**
+ * A request sent to the worker process to emit TypeScript declarations for a
+ * single module.
+ */
 export interface WorkerRequest {
+  /**
+   * Correlation ID used to match a {@linkcode WorkerResponse} back to the
+   * request that produced it.
+   */
   id: number
+
+  /**
+   * The {@linkcode TscOptions} describing the module to emit.
+   */
   options: TscOptions
 }
 
+/**
+ * A response sent back from the worker process after handling a
+ * {@linkcode WorkerRequest}.
+ */
 export interface WorkerResponse {
+  /**
+   * The correlation ID of the originating {@linkcode WorkerRequest}.
+   */
   id: number
+
+  /**
+   * The {@linkcode TscResult} produced on a successful emit.
+   */
   result?: TscResult
+
+  /**
+   * The thrown value captured when the emit failed.
+   */
   error?: unknown
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [x] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#### Summary

- Documents the **`.`** entry: **`dts()`**, **`Options`**, **`GeneralOptions`**, **`TscOptions`**, **`TsgoOptions`**, **`OptionsResolved`**, **`Logger`**, and the re-exported **`createFakeJsPlugin`**, **`createGeneratePlugin`** and **`resolveOptions`**.
- Documents the **`/tsc`**, **`/tsc-context`** and **`/tsc-worker`** entries: **`TscModule`**, **`TscOptions`**, **`TscResult`**, **`TscContext`**, **`ParsedProject`**, **`SourceFileToProjectMap`**, **`WorkerRequest`** and **`WorkerResponse`**.
- Corrects the **`Options.tsconfig`** default from `'tsconfig.json'` to `true` and documents the `true` / `false` / `string` branches.
- Converts the leading `//` comments in **`src/tsc/context.ts`** to JSDoc, preserving their wording.
- Adds `@example` blocks and `{@linkcode}` cross-references, including links to the [**TypeScript `tsconfig` reference**](https://www.typescriptlang.org/tsconfig).
- Leaves the internals (**`src/tsc/emit-build.ts`**, **`src/tsc/emit-compiler.ts`**, **`src/tsc/system.ts`**, **`src/tsc/utils.ts`**, **`src/tsc/resolver.ts`**, **`src/resolver.ts`**, **`src/dts-input.ts`**, **`src/tsgo.ts`**) as they are.