### PR TITLE
fix: preserve external import types

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -7,6 +7,7 @@ import {
   isTypeOf,
   resolveString,
   walkAST,
+  walkASTAsync,
 } from 'ast-kit'
 import {
   filename_dts_to,
@@ -295,8 +296,10 @@ export function createFakeJsPlugin({
       const params: TypeParams = collectParams(decl)
 
       const childrenSet = new Set<t.Node>()
-      const deps = collectDependencies(
+      const deps = await collectDependencies(
+        this,
         decl,
+        id,
         namespaceStmts,
         childrenSet,
         identifierMap,
@@ -903,14 +906,17 @@ function collectParams(node: t.Node): TypeParams {
   }))
 }
 
-function collectDependencies(
+async function collectDependencies(
+  context: TransformPluginContext,
   node: t.Node,
+  importer: string,
   namespaceStmts: NamespaceMap,
   children: Set<t.Node>,
   identifierMap: Record<string, number>,
-): Dep[] {
+): Promise<Dep[]> {
   const deps = new Set<Dep>()
   const seen = new Set<t.Node>()
+  const preserveImportTypeCache = new Map<string, boolean>()
 
   const inferredStack: string[][] = []
   let currentInferred = new Set<string>()
@@ -918,14 +924,15 @@ function collectDependencies(
     return node.type === 'Identifier' && currentInferred.has(node.name)
   }
 
-  walkAST(node, {
+  await walkASTAsync(node, {
     enter(node) {
       if (node.type === 'TSConditionalType') {
         const inferred = collectInferredNames(node.extendsType)
         inferredStack.push(inferred)
       }
+      return Promise.resolve()
     },
-    leave(node, parent) {
+    async leave(node, parent) {
       // handle infer scope
       if (node.type === 'TSConditionalType') {
         inferredStack.pop()
@@ -990,14 +997,18 @@ function collectDependencies(
           case 'TSImportType': {
             seen.add(node)
             const { source, qualifier } = node
-            const dep = importNamespace(
+
+            const dep = await importNamespace(
+              context,
+              importer,
               node,
               qualifier,
               source,
               namespaceStmts,
               identifierMap,
+              preserveImportTypeCache,
             )
-            addDependency(dep)
+            if (dep) addDependency(dep)
             break
           }
         }
@@ -1008,6 +1019,7 @@ function collectDependencies(
       }
     },
   })
+
   return Array.from(deps)
 
   function addDependency(node: Dep) {
@@ -1016,13 +1028,25 @@ function collectDependencies(
   }
 }
 
-function importNamespace(
+async function importNamespace(
+  context: TransformPluginContext,
+  importer: string,
   node: t.TSImportType,
   imported: t.TSEntityName | null | undefined,
   source: t.StringLiteral,
   namespaceStmts: NamespaceMap,
   identifierMap: Record<string, number>,
-): Dep {
+  preserveCache: Map<string, boolean>,
+): Promise<Dep | undefined> {
+  let preserve = preserveCache.get(source.value)
+  if (preserve === undefined) {
+    const resolved = await context.resolve(source.value, importer)
+    preserve = !resolved || !!resolved.external
+    preserveCache.set(source.value, preserve)
+  }
+
+  if (preserve) return
+
   const sourceText = source.value.replaceAll(/\W/g, '_')
   // Use original source if it's already a valid identifier,
   // otherwise use formatted text with index.

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -123,72 +123,54 @@ export { Product };"
 
 exports[`deterministic namespace import index 1`] = `
 "// a.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region a.d.ts
-type MyTypeA = _$stub_lib.LibType;
+type MyTypeA = import('stub_lib').LibType;
 //#endregion
 export { MyTypeA };
 // b.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region b.d.ts
-type MyTypeB = _$stub_lib.LibType;
+type MyTypeB = import('stub_lib').LibType;
 //#endregion
 export { MyTypeB };
 // c.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region c.d.ts
-type MyTypeC = _$stub_lib.LibType;
+type MyTypeC = import('stub_lib').LibType;
 //#endregion
 export { MyTypeC };"
 `;
 
 exports[`deterministic namespace import index 2`] = `
 "// a.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region a.d.ts
-type MyTypeA = _$stub_lib.LibType;
+type MyTypeA = import('stub_lib').LibType;
 //#endregion
 export { MyTypeA };
 // b.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region b.d.ts
-type MyTypeB = _$stub_lib.LibType;
+type MyTypeB = import('stub_lib').LibType;
 //#endregion
 export { MyTypeB };
 // c.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region c.d.ts
-type MyTypeC = _$stub_lib.LibType;
+type MyTypeC = import('stub_lib').LibType;
 //#endregion
 export { MyTypeC };"
 `;
 
 exports[`deterministic namespace import index 3`] = `
 "// a.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region a.d.ts
-type MyTypeA = _$stub_lib.LibType;
+type MyTypeA = import('stub_lib').LibType;
 //#endregion
 export { MyTypeA };
 // b.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region b.d.ts
-type MyTypeB = _$stub_lib.LibType;
+type MyTypeB = import('stub_lib').LibType;
 //#endregion
 export { MyTypeB };
 // c.d.ts
-import * as _$stub_lib from "stub_lib";
-
 //#region c.d.ts
-type MyTypeC = _$stub_lib.LibType;
+type MyTypeC = import('stub_lib').LibType;
 //#endregion
 export { MyTypeC };"
 `;

--- a/tests/__snapshots__/tsc.test.ts.snap
+++ b/tests/__snapshots__/tsc.test.ts.snap
@@ -2,10 +2,8 @@
 
 exports[`tsc > arktype 1`] = `
 "// arktype.d.ts
-import * as _$arktype_internal_variants_object_ts0 from "arktype/internal/variants/object.ts";
-
 //#region tests/fixtures/arktype.d.ts
-declare const test: _$arktype_internal_variants_object_ts0.ObjectType<{
+declare const test: import("arktype/internal/variants/object.ts").ObjectType<{
   test: string;
 }, {}>;
 //#endregion
@@ -479,8 +477,6 @@ export { Unused };"
 
 exports[`tsc > vue-sfc w/ ts-compiler 1`] = `
 "// main.d.ts
-import * as _$_vue_runtime_core0 from "@vue/runtime-core";
-
 //#region tests/fixtures/vue-sfc/App.vue.d.ts
 type __VLS_Props = {
   foo: string;
@@ -490,7 +486,7 @@ declare global {
     foo: string;
   }
 }
-declare const __VLS_export: _$_vue_runtime_core0.DefineComponent<__VLS_Props, {}, {}, {}, {}, _$_vue_runtime_core0.ComponentOptionsMixin, _$_vue_runtime_core0.ComponentOptionsMixin, {}, string, _$_vue_runtime_core0.PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, _$_vue_runtime_core0.ComponentProvideOptions, false, {}, any>;
+declare const __VLS_export: import("@vue/runtime-core").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("@vue/runtime-core").ComponentOptionsMixin, import("@vue/runtime-core").ComponentOptionsMixin, {}, string, import("@vue/runtime-core").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("@vue/runtime-core").ComponentProvideOptions, false, {}, any>;
 declare const _default: typeof __VLS_export;
 //#endregion
 export { _default as App };"
@@ -498,22 +494,20 @@ export { _default as App };"
 
 exports[`tsc > vue-sfc w/ ts-compiler w/ vueCompilerOptions in tsconfig 1`] = `
 "// main.d.ts
-import * as _$vue from "vue";
-
 //#region tests/fixtures/vue-sfc-fallthrough/App.vue.d.ts
-declare const __VLS_export: _$vue.DefineComponent<{
+declare const __VLS_export: import("vue").DefineComponent<{
   foo: string;
   bar?: string | undefined;
   innerHTML?: string | undefined;
-  class?: _$vue.ClassValue;
-  style?: _$vue.StyleValue;
+  class?: import("vue").ClassValue;
+  style?: import("vue").StyleValue;
   accesskey?: string | undefined;
   contenteditable?: (boolean | "true" | "false") | "inherit" | "plaintext-only" | undefined;
   contextmenu?: string | undefined;
   dir?: string | undefined;
   draggable?: (boolean | "true" | "false") | undefined;
   enterkeyhint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
-  enterKeyHint?: _$vue.HTMLAttributes["enterkeyhint"];
+  enterKeyHint?: import("vue").HTMLAttributes["enterkeyhint"];
   hidden?: (boolean | "true" | "false") | "" | "hidden" | "until-found" | undefined;
   id?: string | undefined;
   inert?: (boolean | "true" | "false") | undefined;
@@ -692,28 +686,28 @@ declare const __VLS_export: _$vue.DefineComponent<{
   onTransitionrun?: ((payload: TransitionEvent) => void) | undefined;
   onTransitionstart?: ((payload: TransitionEvent) => void) | undefined;
   key?: PropertyKey | undefined;
-  ref?: _$vue.VNodeRef | undefined;
+  ref?: import("vue").VNodeRef | undefined;
   ref_for?: boolean | undefined | undefined;
   ref_key?: string | undefined | undefined;
-  onVnodeBeforeMount?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeMounted?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeBeforeUpdate?: (((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void) | ((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeUpdated?: (((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void) | ((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeBeforeUnmount?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeUnmounted?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-}, {}, {}, {}, {}, _$vue.ComponentOptionsMixin, _$vue.ComponentOptionsMixin, {}, string, _$vue.PublicProps, Readonly<{
+  onVnodeBeforeMount?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeMounted?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeBeforeUpdate?: (((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void) | ((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeUpdated?: (((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void) | ((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeBeforeUnmount?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeUnmounted?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{
   foo: string;
   bar?: string | undefined;
   innerHTML?: string | undefined;
-  class?: _$vue.ClassValue;
-  style?: _$vue.StyleValue;
+  class?: import("vue").ClassValue;
+  style?: import("vue").StyleValue;
   accesskey?: string | undefined;
   contenteditable?: (boolean | "true" | "false") | "inherit" | "plaintext-only" | undefined;
   contextmenu?: string | undefined;
   dir?: string | undefined;
   draggable?: (boolean | "true" | "false") | undefined;
   enterkeyhint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
-  enterKeyHint?: _$vue.HTMLAttributes["enterkeyhint"];
+  enterKeyHint?: import("vue").HTMLAttributes["enterkeyhint"];
   hidden?: (boolean | "true" | "false") | "" | "hidden" | "until-found" | undefined;
   id?: string | undefined;
   inert?: (boolean | "true" | "false") | undefined;
@@ -892,16 +886,16 @@ declare const __VLS_export: _$vue.DefineComponent<{
   onTransitionrun?: ((payload: TransitionEvent) => void) | undefined;
   onTransitionstart?: ((payload: TransitionEvent) => void) | undefined;
   key?: PropertyKey | undefined;
-  ref?: _$vue.VNodeRef | undefined;
+  ref?: import("vue").VNodeRef | undefined;
   ref_for?: boolean | undefined | undefined;
   ref_key?: string | undefined | undefined;
-  onVnodeBeforeMount?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeMounted?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeBeforeUpdate?: (((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void) | ((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeUpdated?: (((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void) | ((vnode: _$vue.VNode, oldVNode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeBeforeUnmount?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-  onVnodeUnmounted?: (((vnode: _$vue.VNode) => void) | ((vnode: _$vue.VNode) => void)[]) | undefined;
-}> & Readonly<{}>, {}, {}, {}, {}, string, _$vue.ComponentProvideOptions, false, {}, any>;
+  onVnodeBeforeMount?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeMounted?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeBeforeUpdate?: (((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void) | ((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeUpdated?: (((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void) | ((vnode: import("vue").VNode, oldVNode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeBeforeUnmount?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+  onVnodeUnmounted?: (((vnode: import("vue").VNode) => void) | ((vnode: import("vue").VNode) => void)[]) | undefined;
+}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, false, {}, any>;
 declare const _default: typeof __VLS_export;
 //#endregion
 export { _default as App };"
@@ -909,8 +903,6 @@ export { _default as App };"
 
 exports[`tsc > vue-sfc w/ ts-macro w/ ts-compiler 1`] = `
 "// main.d.ts
-import * as _$vue from "vue";
-
 //#region tests/fixtures/vue-sfc-with-ts-macro/App.vue.d.ts
 type __VLS_Props = {
   foo: string;
@@ -920,7 +912,7 @@ declare global {
     foo: string;
   }
 }
-declare const __VLS_export: _$vue.DefineComponent<__VLS_Props, {}, {}, {}, {}, _$vue.ComponentOptionsMixin, _$vue.ComponentOptionsMixin, {}, string, _$vue.PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, _$vue.ComponentProvideOptions, false, {}, any>;
+declare const __VLS_export: import("vue").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, false, {}, any>;
 declare const _default: typeof __VLS_export;
 //#endregion
 //#region tests/fixtures/vue-sfc-with-ts-macro/main.d.ts

--- a/tests/fixtures/cjs-dts-dep-external/index.d.ts
+++ b/tests/fixtures/cjs-dts-dep-external/index.d.ts
@@ -1,0 +1,1 @@
+export const useDep: (dep: import('cjs-dts-dep')) => void

--- a/tests/fixtures/cjs-dts-dep-external/node_modules/cjs-dts-dep/index.d.ts
+++ b/tests/fixtures/cjs-dts-dep-external/node_modules/cjs-dts-dep/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace CjsDtsDep {
+  export interface Value {
+    foo: string
+  }
+}
+export = CjsDtsDep

--- a/tests/fixtures/cjs-dts-dep-external/node_modules/cjs-dts-dep/package.json
+++ b/tests/fixtures/cjs-dts-dep-external/node_modules/cjs-dts-dep/package.json
@@ -1,0 +1,1 @@
+{"name":"cjs-dts-dep","types":"index.d.ts"}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -211,6 +211,25 @@ describe('dts input', () => {
     expect(cjsWarning).toContain('Please mark this module as external')
   })
 
+  test('preserves external CommonJS dts import types', async () => {
+    const root = path.resolve(dirname, 'fixtures/cjs-dts-dep-external')
+
+    const { chunks } = await rolldownBuild(
+      [path.join(root, 'index.d.ts')],
+      [dts({ dtsInput: true })],
+      {
+        cwd: root,
+        external: 'cjs-dts-dep',
+        onwarn(warning) {
+          expect.unreachable(warning.message)
+        },
+      },
+    )
+    expect(chunks[0].code).toContain(
+      "declare const useDep: (dep: import('cjs-dts-dep')) => void",
+    )
+  })
+
   test('input object', async () => {
     const { snapshot, chunks } = await rolldownBuild(
       { index: path.resolve(dirname, 'fixtures/dts-input.d.ts') },
@@ -682,9 +701,8 @@ test('deterministic namespace import index', async () => {
   // All results should be identical
   expect(results[0]).toBe(results[1])
   expect(results[1]).toBe(results[2])
-  // Valid identifiers (stub_lib) don't need index suffix
-  expect(results[0]).toContain('import * as _$stub_lib from "stub_lib"')
-  // Should not have stub_lib0 since each file is independent
+  expect(results[0]).toContain("import('stub_lib').LibType")
+  expect(results[0]).not.toContain('import * as _$stub_lib from "stub_lib"')
   expect(results[0]).not.toContain('stub_lib0')
 })
 

--- a/tests/rollup-plugin-dts/inline-import-external-namespace/known-diff.patch
+++ b/tests/rollup-plugin-dts/inline-import-external-namespace/known-diff.patch
@@ -2,18 +2,13 @@ Index: diff.patch
 ===================================================================
 --- diff.patch
 +++ diff.patch
-@@ -1,15 +1,15 @@
+@@ -1,15 +1,10 @@
  // index.d.ts
 -import * as ___foo_bar from 'foo/bar'
 -import * as __foo_bar from 'foo.bar'
 -import * as _foo_bar from 'foo-bar'
 -import * as foo_bar from 'foo_bar'
 -import * as foo from 'foo'
-+import * as _$foo from 'foo'
-+import * as _$foo_bar from 'foo_bar'
-+import * as _$foo_bar0 from 'foo-bar'
-+import * as _$foo_bar1 from 'foo.bar'
-+import * as _$foo_bar2 from 'foo/bar'
  interface Foo {
 -  ns1: foo
 -  ns2: typeof foo
@@ -21,12 +16,12 @@ Index: diff.patch
 -  ns4: _foo_bar.T
 -  ns5: __foo_bar.T
 -  ns6: ___foo_bar.T
-+  ns1: _$foo
-+  ns2: typeof _$foo
-+  ns3: _$foo_bar.T
-+  ns4: _$foo_bar0.T
-+  ns5: _$foo_bar1.T
-+  ns6: _$foo_bar2.T
++  ns1: import('foo')
++  ns2: typeof import('foo')
++  ns3: import('foo_bar').T
++  ns4: import('foo-bar').T
++  ns5: import('foo.bar').T
++  ns6: import('foo/bar').T
  }
 -export type { Foo }
 +export { Foo }

--- a/tests/rollup-plugin-dts/inline-import-external-namespace/snapshot.d.ts
+++ b/tests/rollup-plugin-dts/inline-import-external-namespace/snapshot.d.ts
@@ -1,18 +1,12 @@
 // index.d.ts
-import * as _$foo from "foo";
-import * as _$foo_bar from "foo_bar";
-import * as _$foo_bar0 from "foo-bar";
-import * as _$foo_bar1 from "foo.bar";
-import * as _$foo_bar2 from "foo/bar";
-
 //#region tests/rollup-plugin-dts/inline-import-external-namespace/index.d.ts
 interface Foo {
-  ns1: _$foo;
-  ns2: typeof _$foo;
-  ns3: _$foo_bar.T;
-  ns4: _$foo_bar0.T;
-  ns5: _$foo_bar1.T;
-  ns6: _$foo_bar2.T;
+  ns1: import("foo");
+  ns2: typeof import("foo");
+  ns3: import('foo_bar').T;
+  ns4: import('foo-bar').T;
+  ns5: import('foo.bar').T;
+  ns6: import('foo/bar').T;
 }
 //#endregion
 export { Foo };

--- a/tests/rollup-plugin-dts/inline-import-typeof-members/known-diff.patch
+++ b/tests/rollup-plugin-dts/inline-import-typeof-members/known-diff.patch
@@ -2,18 +2,16 @@ Index: diff.patch
 ===================================================================
 --- diff.patch
 +++ diff.patch
-@@ -1,12 +1,12 @@
+@@ -1,12 +1,10 @@
  // index.d.ts
 -import * as rollup from 'rollup'
 -import * as typescript from 'typescript'
-+import * as _$typescript from 'typescript'
-+import * as _$rollup from 'rollup'
  type TypeScript =
 -  typeof typescript
-+  typeof _$typescript
++  typeof import('typescript')
  interface Test {
 -  rollup: rollup.RollupOptions
-+  rollup: _$rollup.RollupOptions
++  rollup: import('rollup').RollupOptions
  }
 -export type {
 +export {

--- a/tests/rollup-plugin-dts/inline-import-typeof-members/snapshot.d.ts
+++ b/tests/rollup-plugin-dts/inline-import-typeof-members/snapshot.d.ts
@@ -1,11 +1,8 @@
 // index.d.ts
-import * as _$typescript from "typescript";
-import * as _$rollup from "rollup";
-
 //#region tests/rollup-plugin-dts/inline-import-typeof-members/index.d.ts
-type TypeScript = typeof _$typescript;
+type TypeScript = typeof import("typescript");
 interface Test {
-  rollup: _$rollup.RollupOptions;
+  rollup: import("rollup").RollupOptions;
 }
 //#endregion
 export { Test, TypeScript };


### PR DESCRIPTION
## Summary

- Preserve TS import types when their source resolves as external or unresolved
- Keep namespace import rewriting for bundled internal declaration sources
- Add regression coverage for external CommonJS dts import types and update snapshots

## Tests

- pnpm run format
- pnpm run typecheck
- pnpm run lint
- pnpm test --run