### PR TITLE
fix: track dependencies in computed keys of TSMethodSignature

### DIFF
--- a/src/fake-js.ts
+++ b/src/fake-js.ts
@@ -972,6 +972,7 @@ async function collectDependencies(
           'ClassProperty',
           'TSPropertySignature',
           'TSDeclareMethod',
+          'TSMethodSignature',
         ])
       ) {
         if (node.computed && isReferenceId(node.key)) {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -399,6 +399,23 @@ declare const shared1 = "shared1";
 export { shared1 as t };"
 `;
 
+exports[`method signature 1`] = `
+"// index.d.ts
+//#region tests/fixtures/method-signature/mod.d.ts
+declare const a = "aa";
+declare const b = "bb";
+declare const c = "cc";
+//#endregion
+//#region tests/fixtures/method-signature/index.d.ts
+interface Test {
+  [a]: string;
+  [b](): string;
+  get [c](): string;
+}
+//#endregion
+export { Test };"
+`;
+
 exports[`re-export from lib > both 1`] = `
 "// a.d.ts
 export * from "stub-lib";

--- a/tests/fixtures/method-signature/index.ts
+++ b/tests/fixtures/method-signature/index.ts
@@ -1,0 +1,7 @@
+import * as mod from './mod'
+
+export interface Test {
+  [mod.a]: string
+  [mod.b](): string
+  get [mod.c](): string
+}

--- a/tests/fixtures/method-signature/mod.ts
+++ b/tests/fixtures/method-signature/mod.ts
@@ -1,0 +1,3 @@
+export const a = 'aa'
+export const b = 'bb'
+export const c = 'cc'

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -713,3 +713,11 @@ test('decorators', async () => {
   )
   expect(snapshot).toMatchSnapshot()
 })
+
+test('method signature', async () => {
+  const root = path.resolve(dirname, 'fixtures/method-signature')
+  const { snapshot } = await rolldownBuild(path.resolve(root, 'index.ts'), [
+    dts({ emitDtsOnly: true }),
+  ])
+  expect(snapshot).toMatchSnapshot()
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [ ] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

Fixes an issue where dependencies in computed keys of interface methods (e.g., `[mod.b](): string`) were failing to resolve.

During `collectDependencies`, `TSPropertySignature` was handled, but `TSMethodSignature` was missing from the `isTypeOf` check. This caused the linker to silently ignore computed keys for interface methods.

### Test Case

##### `mod.ts`

```ts
export const a = 'aa'
export const b = 'bb'
export const c = 'cc'
```

##### `index.ts`

```ts
import * as mod from './mod'

export interface Test {
  [mod.a]: string // TSPropertySignature
  [mod.b](): string // TSMethodSignature(kind=method)
  get [mod.c](): string // TSMethodSignature(kind=get)
}
```

##### Actual (Failing):

```ts
declare const a = "aa";
declare const b = "bb";
declare const c = "cc";
interface Test {
  [a]: string;
  [mod.b](): string; // ignored
  get [mod.c](): string; // ignored
}
export { Test };
```

##### Expected:

```ts
declare const a = "aa";
declare const b = "bb";
declare const c = "cc";
interface Test {
  [a]: string;
  [b](): string;
  get [c](): string;
}
export { Test };
```
