### PR TITLE
docs: fix import path for `tsc` context utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ guaranteeing that all type definitions are generated from scratch.
 `invalidateContextFile` API can be used to clear invalidated files from the context.
 
 ```ts
-import { globalContext, invalidateContextFile } from 'rolldown-plugin-dts/tsc'
+import { globalContext, invalidateContextFile } from 'rolldown-plugin-dts/tsc-context'
 invalidateContextFile(globalContext, 'src/foo.ts')
 ```
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [ ] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#### Summary

- Update the **`README.md`** example to import **`globalContext`** and **`invalidateContextFile`** from the **`rolldown-plugin-dts/tsc-context`** subpath.
- The **`rolldown-plugin-dts/tsc`** subpath only exports **`tscEmit`**, so the previous example failed to resolve these bindings.

#### Checklist

- [X] Correct the import specifier in **`README.md`**.
- [X] Verify the example resolves against the package's **`exports`** map in **`package.json`**.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
