### PR TITLE
fix: load `.vue` entries without a `.ts` importer

### DIFF
--- a/src/tsc/emit-compiler.ts
+++ b/src/tsc/emit-compiler.ts
@@ -107,6 +107,13 @@ function createTsProgramFromParsedConfig({
     ...parsedConfig.options,
     $configRaw: parsedConfig.raw,
     $rootDir: baseDir,
+    // Allow non-TS extensions (e.g. `.vue`) to be used as root files. Without
+    // this, TypeScript silently drops root files whose extension is not in its
+    // built-in supported list, so `program.getSourceFile(id)` returns
+    // `undefined` for a `.vue` entry that is not imported by a `.ts` file.
+    // Only relevant when a language plugin (Vue/ts-macro) registers such
+    // extensions; module resolution already handles the imported-file case.
+    ...(vue || tsMacro ? { allowNonTsExtensions: true } : undefined),
   }
 
   const rootNames = [

--- a/tests/__snapshots__/tsc.test.ts.snap
+++ b/tests/__snapshots__/tsc.test.ts.snap
@@ -482,6 +482,27 @@ interface Unused {
 export { Unused };"
 `;
 
+exports[`tsc > vue-sfc as entries w/o ts importer 1`] = `
+"// Bar.vue.d.ts
+//#region tests/fixtures/vue-sfc-entries/Bar.vue.d.ts
+type __VLS_Props = {
+  bar: string;
+};
+declare const __VLS_export: import("@vue/runtime-core").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("@vue/runtime-core").ComponentOptionsMixin, import("@vue/runtime-core").ComponentOptionsMixin, {}, string, import("@vue/runtime-core").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("@vue/runtime-core").ComponentProvideOptions, false, {}, any>;
+declare const _default: typeof __VLS_export;
+//#endregion
+export { _default as default };
+// Foo.vue.d.ts
+//#region tests/fixtures/vue-sfc-entries/Foo.vue.d.ts
+type __VLS_Props = {
+  foo: string;
+};
+declare const __VLS_export: import("@vue/runtime-core").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("@vue/runtime-core").ComponentOptionsMixin, import("@vue/runtime-core").ComponentOptionsMixin, {}, string, import("@vue/runtime-core").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("@vue/runtime-core").ComponentProvideOptions, false, {}, any>;
+declare const _default: typeof __VLS_export;
+//#endregion
+export { _default as default };"
+`;
+
 exports[`tsc > vue-sfc w/ ts-compiler 1`] = `
 "// main.d.ts
 //#region tests/fixtures/vue-sfc/App.vue.d.ts

--- a/tests/fixtures/vue-sfc-entries/Bar.vue
+++ b/tests/fixtures/vue-sfc-entries/Bar.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ bar: string }>()
+</script>
+
+<template>
+  <div>Bar</div>
+</template>

--- a/tests/fixtures/vue-sfc-entries/Foo.vue
+++ b/tests/fixtures/vue-sfc-entries/Foo.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ foo: string }>()
+</script>
+
+<template>
+  <div>Foo</div>
+</template>

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -237,6 +237,24 @@ describe('tsc', () => {
     expect(snapshot).toMatchSnapshot()
   })
 
+  test('vue-sfc as entries w/o ts importer', async () => {
+    const root = path.resolve(dirname, 'fixtures/vue-sfc-entries')
+    const { snapshot } = await rolldownBuild(
+      [path.resolve(root, 'Foo.vue'), path.resolve(root, 'Bar.vue')],
+      [
+        dts({
+          emitDtsOnly: true,
+          vue: true,
+          compilerOptions: {
+            isolatedDeclarations: false,
+          },
+        }),
+      ],
+      { external: [/^@vue/] },
+    )
+    expect(snapshot).toMatchSnapshot()
+  })
+
   test('jsdoc', async () => {
     const { snapshot } = await rolldownBuild(
       path.resolve(dirname, 'fixtures/jsdoc.ts'),


### PR DESCRIPTION
Closes #188

### Problem

When several `.vue` SFCs are used as **direct dts entries** (each `.vue` mapping 1:1 to a package export) and **no `.ts` file imports them**, the build fails with:

> `Unable to load file /abs/path/Foo.vue from the program. This seems like a bug of rolldown-plugin-dts.`

The reporter noticed it works as soon as a `.ts` file importing the `.vue` files is added — and indeed every existing `vue-sfc*` fixture ships a `main.ts` importer, so this scenario was untested.

### Root cause

vue-tsc's own CLI (`@volar/typescript`'s `runTsc`) rewrites TypeScript's source at load time to inject `.vue` into `supportedTSExtensions` / `supportedJSExtensions` / `allSupportedExtensions`. That is what lets TS accept `.vue` files.

This plugin instead calls `proxyCreateProgram` directly and never patches those lists. The proxy installs a custom
`resolveModuleNameLiterals`, so a `.vue` reached **via `import` from a `.ts`** resolves fine and enters the program. But a `.vue` passed as a **root file** goes through TS's `getSourceFileFromReferenceWorker`,
which checks the root file's extension against the built-in supported list, does not find `.vue`, and silently drops it. `program.getSourceFile(id)` then returns `undefined`, triggering the throw in `emit-compiler.ts`.

That is exactly why adding a `.ts` importer "fixes" it (the `.vue` then enters via module resolution instead of as a root), and why it can look flaky depending on entry shape/ordering. In a clean no-importer fixture it reproduces 100% of the time.

### Fix

Set `allowNonTsExtensions: true` on the compiler options, scoped to builds where a language plugin (Vue or ts-macro) is active. This bypasses TS's root-file extension check so root `.vue` entries load deterministically; Volar's `host.getSourceFile` override then produces the virtual TS module as usual. Targeted, not a retry hack.

### Tests

- New fixture `tests/fixtures/vue-sfc-entries/` (`Foo.vue` + `Bar.vue`, no `.ts` importer) listed directly as entries, plus a test in   `tests/tsc.test.ts`. Fails without the fix (reproduced 6/6), passes   with it; correct dts is emitted for both entries.
- `pnpm test`, `pnpm typecheck`, `pnpm lint` all green.

### Note

With `vue: true`, TS will now attempt to load any root file regardless of extension rather than skipping unsupported ones. This matches vue-tsc's behavior and is the intended effect here.