### PR TITLE
feat!: add tsgo API and VFS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ See [rolldown.config.ts](./rolldown.config.ts) for the project's own setup.
 
 ## Generators
 
-| Generator | Use it for                                        | Requirement                                     |
-| --------- | ------------------------------------------------- | ----------------------------------------------- |
-| `tsc`     | Full TypeScript compatibility                     | TypeScript 5.x or 6.x                           |
-| `oxc`     | Fast generation for isolated declarations         | Code compatible with `isolatedDeclarations`     |
-| `tsgo`    | TypeScript Go's asynchronous declaration emit API | A package that exposes the declaration emit API |
+| Generator | Use it for                                        | Requirement                                 |
+| --------- | ------------------------------------------------- | ------------------------------------------- |
+| `tsc`     | Full TypeScript compatibility                     | TypeScript 5.x or 6.x                       |
+| `oxc`     | Fast generation for isolated declarations         | Code compatible with `isolatedDeclarations` |
+| `tsgo`    | TypeScript Go's asynchronous declaration emit API | TypeScript 7.1 or later                     |
 
 When `generator` is omitted, the plugin selects:
 
@@ -150,8 +150,6 @@ dts({
 ### TypeScript Go
 
 The TypeScript Go generator is experimental and requires a `tsconfig.json`.
-It reads compiler options from that file, so `tsconfigRaw` and
-`compilerOptions` are ignored.
 
 `tsgo.moduleUrl` defaults to `import.meta.resolve('typescript')`. It can point
 to an npm alias or another compatible TypeScript module. The selected module

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ When `generator` is omitted, the plugin selects:
 Automatic selection only inspects `typescript`. When `tsgo` is selected
 explicitly, a module without `getDeclarationEmit` reports an error.
 
+`generator` also accepts an object implementing the exported `Generator`
+interface.
+
 ```ts
 dts({
   generator: 'oxc',
@@ -72,7 +75,7 @@ dts({
 
 | Option            | Description                                                                               | Default                 |
 | ----------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
-| `generator`       | Declaration generator: `tsc`, `oxc`, or `tsgo`.                                           | Inferred                |
+| `generator`       | Built-in generator name or a custom `Generator` implementation.                           | Inferred                |
 | `entry`           | Glob or globs selecting files to emit. Supports `!` negation and paths relative to `cwd`. | Rolldown entries        |
 | `cwd`             | Base directory for config discovery, globs, and relative paths.                           | `process.cwd()`         |
 | `dtsInput`        | Treat entry files as existing declarations.                                               | `false`                 |

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ See [rolldown.config.ts](./rolldown.config.ts) for the project's own setup.
 When `generator` is omitted, the plugin selects:
 
 1. `oxc` when `compilerOptions.isolatedDeclarations` is enabled.
-2. `tsgo` for a native `typescript` package.
+2. `tsgo` when `typescript` exposes `Program.prototype.getDeclarationEmit`.
 3. `tsc` otherwise.
 
-Automatic selection only inspects `typescript`. A native package without
-`getDeclarationEmit` reports an error instead of falling back.
+Automatic selection only inspects `typescript`. When `tsgo` is selected
+explicitly, a module without `getDeclarationEmit` reports an error.
 
 ```ts
 dts({

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ npm i -D rolldown-plugin-dts
 Install the compiler required by your generator:
 
 ```bash
-npm i -D typescript@^6              # tsc
-npm i -D @typescript/native-preview # tsgo, unless TypeScript 7 is installed
+npm i -D typescript@^6    # tsc
+npm i -D typescript@next  # tsgo API
 ```
 
 Oxc is provided by Rolldown and needs no additional dependency.
@@ -45,20 +45,20 @@ See [rolldown.config.ts](./rolldown.config.ts) for the project's own setup.
 
 ## Generators
 
-| Generator | Use it for                                              | Requirement                                  |
-| --------- | ------------------------------------------------------- | -------------------------------------------- |
-| `tsc`     | Full TypeScript compatibility, Vue, and Volar languages | TypeScript 5.x or 6.x                        |
-| `oxc`     | Fast generation for isolated declarations               | Code compatible with `isolatedDeclarations`  |
-| `tsgo`    | Experimental TypeScript 7 builds                        | TypeScript 7 or `@typescript/native-preview` |
+| Generator | Use it for                                        | Requirement                                     |
+| --------- | ------------------------------------------------- | ----------------------------------------------- |
+| `tsc`     | Full TypeScript compatibility                     | TypeScript 5.x or 6.x                           |
+| `oxc`     | Fast generation for isolated declarations         | Code compatible with `isolatedDeclarations`     |
+| `tsgo`    | TypeScript Go's asynchronous declaration emit API | A package that exposes the declaration emit API |
 
 When `generator` is omitted, the plugin selects:
 
 1. `oxc` when `compilerOptions.isolatedDeclarations` is enabled.
-2. `tsgo` when TypeScript 7 is installed as `typescript`.
+2. `tsgo` for a native `typescript` package.
 3. `tsc` otherwise.
 
-Volar-based custom languages always require `tsc`. The `tsgo` generator does
-not support custom languages.
+Automatic selection only inspects `typescript`. A native package without
+`getDeclarationEmit` reports an error instead of falling back.
 
 ```ts
 dts({
@@ -149,17 +149,34 @@ dts({
 
 ### TypeScript Go
 
-`tsgo` is experimental and requires a `tsconfig.json`. It reads compiler
-options from that file, so `tsconfigRaw` and `compilerOptions` are ignored.
+The TypeScript Go generator is experimental and requires a `tsconfig.json`.
+It reads compiler options from that file, so `tsconfigRaw` and
+`compilerOptions` are ignored.
+
+`tsgo.moduleUrl` defaults to `import.meta.resolve('typescript')`. It can point
+to an npm alias or another compatible TypeScript module. The selected module
+must expose `Program.prototype.getDeclarationEmit`; there is no package-name
+fallback.
+
+`tsgo.vfs` defaults to `false` and only affects `tsgo`.
 
 ```ts
 dts({
   generator: 'tsgo',
   tsgo: {
-    path: '/path/to/tsgo',
+    moduleUrl: import.meta.resolve('typescript'),
+    path: '/path/to/tsserver',
+    vfs: true,
   },
 })
 ```
+
+For example, a separately installed npm alias can be selected with
+`moduleUrl: import.meta.resolve('typescript-next')`.
+
+With VFS enabled, `tsgo` receives the transformed code observed by the dts
+transform hook instead of rereading source files from disk. Source-transforming
+plugins must appear before `dts()` for their output to be included.
 
 ## Vite
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ dts({
 | Option            | Description                                                                               | Default                 |
 | ----------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
 | `generator`       | Built-in generator name or a custom `Generator` implementation.                           | Inferred                |
+| `tsc`             | Options for the built-in `tsc` generator.                                                 | `{}`                    |
 | `entry`           | Glob or globs selecting files to emit. Supports `!` negation and paths relative to `cwd`. | Rolldown entries        |
 | `cwd`             | Base directory for config discovery, globs, and relative paths.                           | `process.cwd()`         |
 | `dtsInput`        | Treat entry files as existing declarations.                                               | `false`                 |
@@ -102,17 +103,17 @@ CommonJS-style declaration input.
 
 ### TypeScript (`tsc`)
 
-| Option        | Description                                                   | Default                                  |
-| ------------- | ------------------------------------------------------------- | ---------------------------------------- |
-| `build`       | Use TypeScript build mode and follow project references.      | `false`                                  |
-| `incremental` | Persist build outputs, including `.tsbuildinfo`, to disk.     | Enabled by the matching tsconfig options |
-| `vue`         | Register the built-in Vue integration using `vue-tsc`.        | `false`                                  |
-| `parallel`    | Run `tsc` or `vue-tsc` in a separate process.                 | `false`                                  |
-| `eager`       | Load every file listed by `tsconfig.json`.                    | `false`                                  |
-| `newContext`  | Use an isolated compiler cache instead of the shared context. | `false`                                  |
-| `emitJs`      | Generate declarations for JavaScript files with JSDoc types.  | `allowJs` or `checkJs`                   |
+| Option            | Description                                                   | Default                                  |
+| ----------------- | ------------------------------------------------------------- | ---------------------------------------- |
+| `tsc.build`       | Use TypeScript build mode and follow project references.      | `false`                                  |
+| `tsc.incremental` | Persist build outputs, including `.tsbuildinfo`, to disk.     | Enabled by the matching tsconfig options |
+| `vue`             | Register the built-in Vue integration using `vue-tsc`.        | `false`                                  |
+| `tsc.parallel`    | Run `tsc` or `vue-tsc` in a separate process.                 | `false`                                  |
+| `tsc.eager`       | Load every file listed by `tsconfig.json`.                    | `false`                                  |
+| `tsc.newContext`  | Use an isolated compiler cache instead of the shared context. | `false`                                  |
+| `emitJs`          | Generate declarations for JavaScript files with JSDoc types.  | `allowJs` or `checkJs`                   |
 
-`incremental` applies to build mode. When disabled, build outputs stay in
+`tsc.incremental` applies to build mode. When disabled, build outputs stay in
 memory.
 
 To invalidate a file in the shared compiler cache:

--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -9,6 +9,18 @@ export interface CustomLanguage {
   volarTypeScript?: typeof import("@volar/typescript");
   createVolarPlugins?: Parameters<(typeof import("@volar/typescript"))["proxyCreateProgram"]>[2];
 }
+export interface Generator {
+  init?: () => void | Promise<void>;
+  addFile?: (_: string, _: string) => void;
+  emit: (_: string, _: string) => GeneratorResult | Promise<GeneratorResult>;
+  dispose?: () => void | Promise<void>;
+  invalidate?: (_: string) => void;
+}
+export interface GeneratorResult {
+  code?: string;
+  map?: SourceMapInput;
+  error?: RollupError | string;
+}
 export interface Logger {
   info: (..._: any[]) => void;
   warn: (..._: any[]) => void;
@@ -30,7 +42,7 @@ export declare function resolveOptions({ generator, entry, cwd, dtsInput, emitDt
 
 // #region Referenced (internal)
 interface GeneralOptions {
-  generator?: "tsc" | "oxc" | "tsgo";
+  generator?: "tsc" | "oxc" | "tsgo" | Generator;
   entry?: string | string[];
   cwd?: string;
   dtsInput?: boolean;

--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -62,6 +62,8 @@ interface TscOptions {
   emitJs?: boolean;
 }
 interface TsgoOptions {
+  moduleUrl?: string;
   path?: string;
+  vfs?: boolean;
 }
 // #endregion

--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -26,22 +26,7 @@ export interface Logger {
   warn: (..._: any[]) => void;
   error: (..._: any[]) => void;
 }
-export interface Options extends GeneralOptions, TscOptions {
-  oxc?: Omit<IsolatedDeclarationsOptions, "sourcemap">;
-  tsgo?: TsgoOptions;
-  customLanguages?: CustomLanguage[];
-}
-// #endregion
-
-// #region Functions
-export declare function createFakeJsPlugin({ sourcemap, cjsDefault, sideEffects }: Pick<OptionsResolved, "sourcemap" | "cjsDefault" | "sideEffects">): Plugin;
-export declare function createGeneratePlugin(_: Pick<OptionsResolved, "generator" | "entry" | "cwd" | "tsconfig" | "tsconfigRaw" | "build" | "incremental" | "oxc" | "emitDtsOnly" | "languageContext" | "vue" | "parallel" | "eager" | "tsgo" | "newContext" | "emitJs" | "sourcemap">): Plugin;
-export declare function dts(_?: Options): Plugin[];
-export declare function resolveOptions({ generator, entry, cwd, dtsInput, emitDtsOnly, tsconfig, tsconfigRaw: overriddenTsconfigRaw, compilerOptions, sourcemap, resolver, cjsDefault, sideEffects, logger, customLanguages, build, incremental, vue, parallel, eager, newContext, emitJs, oxc, tsgo }: Options): OptionsResolved;
-// #endregion
-
-// #region Referenced (internal)
-interface GeneralOptions {
+export interface Options {
   generator?: "tsc" | "oxc" | "tsgo" | Generator;
   entry?: string | string[];
   cwd?: string;
@@ -55,8 +40,31 @@ interface GeneralOptions {
   cjsDefault?: boolean;
   sideEffects?: boolean;
   logger?: Logger;
+  vue?: boolean | VueLanguageOptions;
+  emitJs?: boolean;
+  tsc?: TscOptions;
+  oxc?: Omit<IsolatedDeclarationsOptions, "sourcemap">;
+  tsgo?: TsgoOptions;
+  customLanguages?: CustomLanguage[];
 }
-type OptionsResolved = Overwrite<Required<Omit<Options, "compilerOptions" | "vue" | "customLanguages">>, {
+export interface TscOptions {
+  build?: boolean;
+  incremental?: boolean;
+  parallel?: boolean;
+  eager?: boolean;
+  newContext?: boolean;
+}
+// #endregion
+
+// #region Functions
+export declare function createFakeJsPlugin({ sourcemap, cjsDefault, sideEffects }: Pick<OptionsResolved, "sourcemap" | "cjsDefault" | "sideEffects">): Plugin;
+export declare function createGeneratePlugin(_: Pick<OptionsResolved, "generator" | "entry" | "cwd" | "tsconfig" | "tsconfigRaw" | "oxc" | "emitDtsOnly" | "languageContext" | "vue" | "tsc" | "tsgo" | "emitJs" | "sourcemap">): Plugin;
+export declare function dts(_?: Options): Plugin[];
+export declare function resolveOptions({ generator, entry, cwd, dtsInput, emitDtsOnly, tsconfig, tsconfigRaw: overriddenTsconfigRaw, compilerOptions, sourcemap, resolver, cjsDefault, sideEffects, logger, customLanguages, tsc, vue, emitJs, oxc, tsgo }: Options): OptionsResolved;
+// #endregion
+
+// #region Referenced (internal)
+type OptionsResolved = Overwrite<Required<Omit<Options, "compilerOptions" | "vue" | "customLanguages" | "tsc">>, {
   entry?: string[];
   tsconfig?: string;
   oxc: IsolatedDeclarationsOptions;
@@ -64,16 +72,8 @@ type OptionsResolved = Overwrite<Required<Omit<Options, "compilerOptions" | "vue
   tsgo: TsgoOptions;
   languageContext: LanguageContext;
   vue: false | VueLanguageOptions;
+  tsc: Required<TscOptions>;
 }>;
-interface TscOptions {
-  build?: boolean;
-  incremental?: boolean;
-  vue?: boolean | VueLanguageOptions;
-  parallel?: boolean;
-  eager?: boolean;
-  newContext?: boolean;
-  emitJs?: boolean;
-}
 interface TsgoOptions {
   moduleUrl?: string;
   path?: string;

--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -35,7 +35,7 @@ export interface Options extends GeneralOptions, TscOptions {
 
 // #region Functions
 export declare function createFakeJsPlugin({ sourcemap, cjsDefault, sideEffects }: Pick<OptionsResolved, "sourcemap" | "cjsDefault" | "sideEffects">): Plugin;
-export declare function createGeneratePlugin(_: Pick<OptionsResolved, "generator" | "entry" | "cwd" | "tsconfig" | "tsconfigRaw" | "build" | "incremental" | "oxc" | "emitDtsOnly" | "languageContext" | "parallel" | "eager" | "tsgo" | "newContext" | "emitJs" | "sourcemap">): Plugin;
+export declare function createGeneratePlugin(_: Pick<OptionsResolved, "generator" | "entry" | "cwd" | "tsconfig" | "tsconfigRaw" | "build" | "incremental" | "oxc" | "emitDtsOnly" | "languageContext" | "vue" | "parallel" | "eager" | "tsgo" | "newContext" | "emitJs" | "sourcemap">): Plugin;
 export declare function dts(_?: Options): Plugin[];
 export declare function resolveOptions({ generator, entry, cwd, dtsInput, emitDtsOnly, tsconfig, tsconfigRaw: overriddenTsconfigRaw, compilerOptions, sourcemap, resolver, cjsDefault, sideEffects, logger, customLanguages, build, incremental, vue, parallel, eager, newContext, emitJs, oxc, tsgo }: Options): OptionsResolved;
 // #endregion
@@ -63,6 +63,7 @@ type OptionsResolved = Overwrite<Required<Omit<Options, "compilerOptions" | "vue
   tsconfigRaw: TsconfigJson;
   tsgo: TsgoOptions;
   languageContext: LanguageContext;
+  vue: false | VueLanguageOptions;
 }>;
 interface TscOptions {
   build?: boolean;

--- a/package.json
+++ b/package.json
@@ -55,16 +55,12 @@
     "prepack": "pnpm run build"
   },
   "peerDependencies": {
-    "@typescript/native-preview": "*",
     "@volar/typescript": "~2.4.0",
     "rolldown": "^1.2.0",
-    "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0",
+    "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0 || ~7.1.0-0",
     "vue-tsc": "~3.2.0 || ~3.3.0"
   },
   "peerDependenciesMeta": {
-    "@typescript/native-preview": {
-      "optional": true
-    },
     "@volar/typescript": {
       "optional": true
     },
@@ -92,7 +88,6 @@
     "@ts-macro/language-plugin": "catalog:",
     "@ts-macro/tsc": "catalog:",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
     "@volar/typescript": "catalog:",
     "@vue/language-core": "catalog:",
     "arktype": "catalog:",
@@ -104,6 +99,7 @@
     "tsdown": "catalog:",
     "tsnapi": "catalog:",
     "typescript": "catalog:",
+    "typescript-next": "catalog:",
     "vitest": "catalog:",
     "vue": "catalog:",
     "vue-tsc": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ catalogs:
     '@types/node':
       specifier: ^26.4.0
       version: 26.4.0
-    '@typescript/native-preview':
-      specifier: npm:typescript@^7.0.2
-      version: 7.0.2
     '@volar/typescript':
       specifier: ^2.4.28
       version: 2.4.28
@@ -164,6 +161,9 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+    typescript-next:
+      specifier: npm:typescript@next
+      version: 7.1.0-dev.20260830.1
     vitest:
       specifier: ^4.1.11
       version: 4.1.11
@@ -246,9 +246,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.4.0
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@volar/typescript':
         specifier: 'catalog:'
         version: 2.4.28(typescript@6.0.3)
@@ -275,13 +272,16 @@ importers:
         version: 0.3.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.14(@volar/typescript@2.4.28(typescript@6.0.3))(typescript@6.0.3)(typescript@7.0.2)(vue-tsc@3.3.11(typescript@6.0.3))
+        version: 0.22.14(@volar/typescript@2.4.28(typescript@6.0.3))(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))
       tsnapi:
         specifier: 'catalog:'
         version: 1.4.0(srvx@0.12.7)(vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0)))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      typescript-next:
+        specifier: 'catalog:'
+        version: typescript@7.1.0-dev.20260830.1
       vitest:
         specifier: 'catalog:'
         version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -1029,122 +1029,44 @@ packages:
     resolution: {integrity: sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/typescript-aix-ppc64@7.0.2':
-    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@typescript/typescript-darwin-arm64@7.0.2':
-    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-qhUW/7KAg/zaCTmtKg+gyP3r68Buld8PIHLgK45+rxCQsQzKq0AL5RIe8nRmgH8GrMp3rX5uYFEz8hJM2r4Tew==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/typescript-darwin-x64@7.0.2':
-    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+  '@typescript/typescript-darwin-x64@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-NBc8LrddWv2E+d1zKrP5cXMuU0hpIdB7MIZCpxgcfmhsUuo+jsLy9ktuws4PdX+XyZmbW9PEDRES12WAi/DdEg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/typescript-freebsd-arm64@7.0.2':
-    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@typescript/typescript-freebsd-x64@7.0.2':
-    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@typescript/typescript-linux-arm64@7.0.2':
-    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+  '@typescript/typescript-linux-arm64@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-/xXknEuRRjWJNnlVC0dbbteVzHlH2ZAlbucSAP/UFohkaCtfS87k6SpG0/VTfwkv7cQEPAIRP6qG9xkVurZPGQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/typescript-linux-arm@7.0.2':
-    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+  '@typescript/typescript-linux-arm@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-GBrFXo6XTn64ZaPM3f2ix9hnwsPcPwPwYTMS/BCmCICRPDjSgAtpV8ZqZrMHoNp7S2BzQjW/UzkqLafl41hEIw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/typescript-linux-loong64@7.0.2':
-    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@typescript/typescript-linux-mips64el@7.0.2':
-    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@typescript/typescript-linux-ppc64@7.0.2':
-    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@typescript/typescript-linux-riscv64@7.0.2':
-    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@typescript/typescript-linux-s390x@7.0.2':
-    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@typescript/typescript-linux-x64@7.0.2':
-    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+  '@typescript/typescript-linux-x64@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-9LAECeM1QR6fkx83bNd0mB9cCaltfASxI/fZ/rqgrSWcCPq7j2JbdXrIeafP553JWkVidzfzB/tl3tlr2sm6Gw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/typescript-netbsd-arm64@7.0.2':
-    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@typescript/typescript-netbsd-x64@7.0.2':
-    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@typescript/typescript-openbsd-arm64@7.0.2':
-    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@typescript/typescript-openbsd-x64@7.0.2':
-    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@typescript/typescript-sunos-x64@7.0.2':
-    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@typescript/typescript-win32-arm64@7.0.2':
-    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+  '@typescript/typescript-win32-arm64@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-XxXMpOpmhu1dxaY4Y5OJdcKBHDjJaweEOor3hQp7AaKZLueYDDWHT8uzhE+6xye4xxkVzCQjbG/3Hpxdxk8JaA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/typescript-win32-x64@7.0.2':
-    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+  '@typescript/typescript-win32-x64@7.1.0-dev.20260830.1':
+    resolution: {integrity: sha512-iU0vE/nik1/WNZ9GwVCYGVw1lWrjdxmkEq2LJbqGdYm0g/noYW92Q8DW/1my0DqX/ggQKLHLfxoR6alWvCENGQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
@@ -2789,8 +2711,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@7.0.2:
-    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+  typescript@7.1.0-dev.20260830.1:
+    resolution: {integrity: sha512-eJVnD3qImawDkJhjlH5y+X1jY+ybdFzYnWcBnOZGS4tveuR5sA/+4wKngInLlIASm/Q/trSEM14fMh3d6hyufQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -3650,64 +3572,25 @@ snapshots:
       '@typescript-eslint/types': 8.68.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/typescript-aix-ppc64@7.0.2':
+  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260830.1':
     optional: true
 
-  '@typescript/typescript-darwin-arm64@7.0.2':
+  '@typescript/typescript-darwin-x64@7.1.0-dev.20260830.1':
     optional: true
 
-  '@typescript/typescript-darwin-x64@7.0.2':
+  '@typescript/typescript-linux-arm64@7.1.0-dev.20260830.1':
     optional: true
 
-  '@typescript/typescript-freebsd-arm64@7.0.2':
+  '@typescript/typescript-linux-arm@7.1.0-dev.20260830.1':
     optional: true
 
-  '@typescript/typescript-freebsd-x64@7.0.2':
+  '@typescript/typescript-linux-x64@7.1.0-dev.20260830.1':
     optional: true
 
-  '@typescript/typescript-linux-arm64@7.0.2':
+  '@typescript/typescript-win32-arm64@7.1.0-dev.20260830.1':
     optional: true
 
-  '@typescript/typescript-linux-arm@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-loong64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-mips64el@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-ppc64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-riscv64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-s390x@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-netbsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-netbsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-openbsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-openbsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-sunos-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-win32-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-win32-x64@7.0.2':
+  '@typescript/typescript-win32-x64@7.1.0-dev.20260830.1':
     optional: true
 
   '@ungap/structured-clone@1.4.0': {}
@@ -5230,7 +5113,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.6)(typescript@6.0.3)(typescript@7.0.2)(vue-tsc@3.3.11(typescript@6.0.3)):
+  rolldown-plugin-dts@0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.6)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3)):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -5240,7 +5123,6 @@ snapshots:
       yuku-codegen: 0.8.7
       yuku-parser: 0.8.7
     optionalDependencies:
-      '@typescript/native-preview': typescript@7.0.2
       '@volar/typescript': 2.4.28(typescript@6.0.3)
       typescript: 6.0.3
       vue-tsc: 3.3.11(typescript@6.0.3)
@@ -5374,7 +5256,7 @@ snapshots:
     dependencies:
       muggle-string: 0.4.1
 
-  tsdown@0.22.14(@volar/typescript@2.4.28(typescript@6.0.3))(typescript@6.0.3)(typescript@7.0.2)(vue-tsc@3.3.11(typescript@6.0.3)):
+  tsdown@0.22.14(@volar/typescript@2.4.28(typescript@6.0.3))(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3)):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -5385,7 +5267,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.7
       rolldown: 1.2.6
-      rolldown-plugin-dts: 0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.6)(typescript@6.0.3)(typescript@7.0.2)(vue-tsc@3.3.11(typescript@6.0.3))
+      rolldown-plugin-dts: 0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.6)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -5438,28 +5320,15 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  typescript@7.0.2:
+  typescript@7.1.0-dev.20260830.1:
     optionalDependencies:
-      '@typescript/typescript-aix-ppc64': 7.0.2
-      '@typescript/typescript-darwin-arm64': 7.0.2
-      '@typescript/typescript-darwin-x64': 7.0.2
-      '@typescript/typescript-freebsd-arm64': 7.0.2
-      '@typescript/typescript-freebsd-x64': 7.0.2
-      '@typescript/typescript-linux-arm': 7.0.2
-      '@typescript/typescript-linux-arm64': 7.0.2
-      '@typescript/typescript-linux-loong64': 7.0.2
-      '@typescript/typescript-linux-mips64el': 7.0.2
-      '@typescript/typescript-linux-ppc64': 7.0.2
-      '@typescript/typescript-linux-riscv64': 7.0.2
-      '@typescript/typescript-linux-s390x': 7.0.2
-      '@typescript/typescript-linux-x64': 7.0.2
-      '@typescript/typescript-netbsd-arm64': 7.0.2
-      '@typescript/typescript-netbsd-x64': 7.0.2
-      '@typescript/typescript-openbsd-arm64': 7.0.2
-      '@typescript/typescript-openbsd-x64': 7.0.2
-      '@typescript/typescript-sunos-x64': 7.0.2
-      '@typescript/typescript-win32-arm64': 7.0.2
-      '@typescript/typescript-win32-x64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.1.0-dev.20260830.1
+      '@typescript/typescript-darwin-x64': 7.1.0-dev.20260830.1
+      '@typescript/typescript-linux-arm': 7.1.0-dev.20260830.1
+      '@typescript/typescript-linux-arm64': 7.1.0-dev.20260830.1
+      '@typescript/typescript-linux-x64': 7.1.0-dev.20260830.1
+      '@typescript/typescript-win32-arm64': 7.1.0-dev.20260830.1
+      '@typescript/typescript-win32-x64': 7.1.0-dev.20260830.1
 
   ufo@1.6.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ catalog:
   '@ts-macro/language-plugin': ^0.3.7
   '@ts-macro/tsc': ^0.3.7
   '@types/node': ^26.4.0
-  '@typescript/native-preview': 'npm:typescript@^7.0.2'
   '@volar/typescript': ^2.4.28
   '@vue/language-core': ^3.3.11
   arktype: ^2.2.3
@@ -22,6 +21,7 @@ catalog:
   tsdown: ^0.22.14
   tsnapi: ^1.4.0
   typescript: ^6.0.3
+  typescript-next: 'npm:typescript@next'
   vitest: ^4.1.11
   vue: ^3.5.42
   vue-tsc: ^3.3.11

--- a/src/custom-language.ts
+++ b/src/custom-language.ts
@@ -16,7 +16,10 @@ export interface CustomLanguage {
   /** Extra file extensions passed to the TypeScript compiler. */
   tsFileExtensionInfos?: FileExtensionInfo[]
 
-  /** Maps a source filename to the TypeScript filename used for declarations. */
+  /**
+   * Maps a source filename to the TypeScript filename used for declarations.
+   * Required for custom file extensions.
+   */
   toTsFilename?: (id: string) => string
 
   /** @ts-ignore - optional dep */

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -40,21 +40,17 @@ export function createGeneratePlugin(
     | 'cwd'
     | 'tsconfig'
     | 'tsconfigRaw'
-    | 'build'
-    | 'incremental'
     | 'oxc'
     | 'emitDtsOnly'
     | 'languageContext'
     | 'vue'
-    | 'parallel'
-    | 'eager'
+    | 'tsc'
     | 'tsgo'
-    | 'newContext'
     | 'emitJs'
     | 'sourcemap'
   >,
 ): Plugin {
-  const { entry, cwd, emitDtsOnly, languageContext, eager, emitJs } = options
+  const { entry, cwd, emitDtsOnly, languageContext, tsc, emitJs } = options
   const entryIncludes = entry?.filter((p) => p[0] !== '!')
   const entryIgnores = entry?.filter((p) => p[0] === '!').map((p) => p.slice(1))
   const entryMatcher = entry
@@ -76,7 +72,7 @@ export function createGeneratePlugin(
   const inputAliasMap = new Map<string, string>()
 
   const declarationGenerator = createGenerator(options, () =>
-    eager
+    tsc.eager
       ? undefined
       : Array.from(dtsMap.values())
           .filter((module) => module.isEntry)

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -45,6 +45,7 @@ export function createGeneratePlugin(
     | 'oxc'
     | 'emitDtsOnly'
     | 'languageContext'
+    | 'vue'
     | 'parallel'
     | 'eager'
     | 'tsgo'

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -151,6 +151,7 @@ export function createGeneratePlugin(
             : !!mod?.isEntry
           const dtsId = filename_to_dts(id, languageContext)
           dtsMap.set(dtsId, { code, id, isEntry, jsFile })
+          declarationGenerator.addFile?.(code, id)
           debug('register dts source: %s', id)
 
           if (isEntry) {

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -40,6 +40,7 @@ export function createGenerator(
     cwd,
     oxc,
     languageContext,
+    vue,
     parallel,
     tsgo,
     newContext,
@@ -54,6 +55,7 @@ export function createGenerator(
     | 'cwd'
     | 'oxc'
     | 'languageContext'
+    | 'vue'
     | 'parallel'
     | 'tsgo'
     | 'newContext'
@@ -86,6 +88,7 @@ export function createGenerator(
     cwd,
     sourcemap,
     languageContext,
+    vue,
     parallel,
     newContext,
     getEntries,

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { OxcGenerator } from './oxc.ts'
 import { TscGenerator } from './tsc.ts'
 import { TsgoGenerator } from './tsgo.ts'
@@ -13,6 +12,7 @@ export interface GeneratorResult {
 
 export interface Generator {
   init?: () => void | Promise<void>
+  addFile?: (code: string, fileName: string) => void
   emit: (
     code: string,
     fileName: string,
@@ -58,10 +58,11 @@ export function createGenerator(
 
   if (generator === 'tsgo') {
     return new TsgoGenerator({
-      tsgoPath: tsgo.path!,
-      rootDir: tsconfig ? path.dirname(tsconfig) : cwd,
+      moduleUrl: tsgo.moduleUrl,
+      tsgoPath: tsgo.path,
+      cwd,
       tsconfig: tsconfig!,
-      sourcemap,
+      vfs: !!tsgo.vfs,
       languageContext,
     })
   }

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -5,19 +5,28 @@ import type { OptionsResolved } from '../options.ts'
 import type { RollupError, SourceMapInput } from 'rolldown'
 
 export interface GeneratorResult {
+  /** Generated declaration code. */
   code?: string
+  /** Source map for the generated declaration. */
   map?: SourceMapInput
+  /** Error reported through Rolldown when declaration generation fails. */
   error?: RollupError | string
 }
 
+/** A declaration generator used by the dts plugin. */
 export interface Generator {
+  /** Initializes resources at the start of each build. */
   init?: () => void | Promise<void>
+  /** Registers transformed source code before declaration generation. */
   addFile?: (code: string, fileName: string) => void
+  /** Generates a declaration for a source file. */
   emit: (
     code: string,
     fileName: string,
   ) => GeneratorResult | Promise<GeneratorResult>
+  /** Releases resources at the end of each build. */
   dispose?: () => void | Promise<void>
+  /** Invalidates cached state for a changed file in watch mode. */
   invalidate?: (fileName: string) => void
 }
 
@@ -52,6 +61,8 @@ export function createGenerator(
   >,
   getEntries: () => string[] | undefined,
 ): Generator {
+  if (typeof generator !== 'string') return generator
+
   if (generator === 'oxc') {
     return new OxcGenerator(oxc, languageContext)
   }

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -35,30 +35,24 @@ export function createGenerator(
     generator,
     tsconfig,
     tsconfigRaw,
-    build,
-    incremental,
     cwd,
     oxc,
     languageContext,
     vue,
-    parallel,
+    tsc,
     tsgo,
-    newContext,
     sourcemap,
   }: Pick<
     OptionsResolved,
     | 'generator'
     | 'tsconfig'
     | 'tsconfigRaw'
-    | 'build'
-    | 'incremental'
     | 'cwd'
     | 'oxc'
     | 'languageContext'
     | 'vue'
-    | 'parallel'
+    | 'tsc'
     | 'tsgo'
-    | 'newContext'
     | 'sourcemap'
   >,
   getEntries: () => string[] | undefined,
@@ -83,14 +77,14 @@ export function createGenerator(
   return new TscGenerator({
     tsconfig,
     tsconfigRaw,
-    build,
-    incremental,
+    build: tsc.build,
+    incremental: tsc.incremental,
     cwd,
     sourcemap,
     languageContext,
     vue,
-    parallel,
-    newContext,
+    parallel: tsc.parallel,
+    newContext: tsc.newContext,
     getEntries,
   })
 }

--- a/src/generator/tsc.ts
+++ b/src/generator/tsc.ts
@@ -164,7 +164,7 @@ function createTscWorker(vue: false | VueLanguageOptions): TscWorker {
         childProcess.send({
           id,
           options,
-          ...(vue ? { vue } : undefined),
+          vue: vue || undefined,
         } satisfies WorkerRequest)
       }),
     kill: () => childProcess.kill(),

--- a/src/generator/tsc.ts
+++ b/src/generator/tsc.ts
@@ -9,19 +9,27 @@ import {
   type TscContext,
 } from '../tsc/context.ts'
 import type { TscOptions, TscResult } from '../tsc/index.ts'
-import type { WorkerRequest, WorkerResponse } from '../tsc/worker.ts'
+import type { VueLanguageOptions } from '../tsc/vue.ts'
+import type {
+  WorkerRequest,
+  WorkerResponse,
+  WorkerTscOptions,
+} from '../tsc/worker.ts'
 import type { Generator } from './index.ts'
 
 const WORKER_URL = import.meta.WORKER_URL || '../tsc/worker.ts'
 
 type TscGeneratorOptions = Omit<TscOptions, 'id' | 'entries' | 'context'> & {
+  vue: false | VueLanguageOptions
   parallel: boolean
   newContext: boolean
   getEntries: () => string[] | undefined
 }
 
 export class TscGenerator implements Generator {
-  private options: Omit<TscOptions, 'id' | 'entries' | 'context'>
+  private options: Omit<WorkerTscOptions, 'id' | 'entries'>
+  private languageContext: TscOptions['languageContext']
+  private vue: false | VueLanguageOptions
   private parallel: boolean
   private newContext: boolean
   private getEntries: () => string[] | undefined
@@ -33,9 +41,13 @@ export class TscGenerator implements Generator {
     parallel,
     newContext,
     getEntries,
+    languageContext,
+    vue,
     ...options
   }: TscGeneratorOptions) {
     this.options = options
+    this.languageContext = languageContext
+    this.vue = vue
     this.parallel = parallel
     this.newContext = newContext
     this.getEntries = getEntries
@@ -43,7 +55,7 @@ export class TscGenerator implements Generator {
 
   async init(): Promise<void> {
     if (this.parallel) {
-      this.worker = createTscWorker()
+      this.worker = createTscWorker(this.vue)
       return
     }
 
@@ -54,11 +66,10 @@ export class TscGenerator implements Generator {
   }
 
   async emit(_code: string, fileName: string): Promise<TscResult> {
-    const options: TscOptions = {
+    const options: WorkerTscOptions = {
       ...this.options,
       entries: this.getEntries(),
       id: fileName,
-      context: this.context,
     }
 
     let result: TscResult
@@ -71,7 +82,11 @@ export class TscGenerator implements Generator {
       if (!this.tscModule) {
         throw new Error('TscGenerator has not been initialized.')
       }
-      result = this.tscModule.tscEmit(options)
+      result = this.tscModule.tscEmit({
+        ...options,
+        languageContext: this.languageContext,
+        context: this.context,
+      })
     }
 
     if (result.code && RE_JSON.test(fileName)) {
@@ -104,11 +119,11 @@ export class TscGenerator implements Generator {
 }
 
 interface TscWorker {
-  emit: (options: TscOptions) => Promise<TscResult>
+  emit: (options: WorkerTscOptions) => Promise<TscResult>
   kill: () => void
 }
 
-function createTscWorker(): TscWorker {
+function createTscWorker(vue: false | VueLanguageOptions): TscWorker {
   const childProcess = fork(new URL(WORKER_URL, import.meta.url), {
     stdio: 'inherit',
     serialization: 'advanced',
@@ -146,7 +161,11 @@ function createTscWorker(): TscWorker {
       new Promise((resolve, reject) => {
         const id = nextId++
         pending.set(id, { resolve, reject })
-        childProcess.send({ id, options } satisfies WorkerRequest)
+        childProcess.send({
+          id,
+          options,
+          ...(vue ? { vue } : undefined),
+        } satisfies WorkerRequest)
       }),
     kill: () => childProcess.kill(),
   }

--- a/src/generator/tsgo.ts
+++ b/src/generator/tsgo.ts
@@ -39,7 +39,7 @@ export class TsgoGenerator implements Generator {
     this.openedFiles.clear()
     this.emitQueue = Promise.resolve()
 
-    this.apiModule = await loadTsgoApi(this.options.moduleUrl)
+    this.apiModule = loadTsgoApi(this.options.moduleUrl)
     const { tsgoPath, cwd, tsconfig, vfs } = this.options
     const fs = vfs ? this.createFileSystem() : undefined
     this.api = new this.apiModule.API({

--- a/src/generator/tsgo.ts
+++ b/src/generator/tsgo.ts
@@ -19,10 +19,6 @@ export interface TsgoGeneratorOptions {
   languageContext: LanguageContext
 }
 
-function normalizeFileName(fileName: string): string {
-  return path.resolve(fileName)
-}
-
 export class TsgoGenerator implements Generator {
   private options: TsgoGeneratorOptions
   private apiModule?: TsgoApiModule
@@ -97,13 +93,13 @@ export class TsgoGenerator implements Generator {
 
   private createFileSystem(): FileSystem {
     return {
-      readFile: (fileName) => this.activeFiles.get(normalizeFileName(fileName)),
+      readFile: (fileName) => this.activeFiles.get(path.resolve(fileName)),
       fileExists: (fileName) =>
-        this.activeFiles.has(normalizeFileName(fileName)) ? true : undefined,
+        this.activeFiles.has(path.resolve(fileName)) ? true : undefined,
       directoryExists: (directoryName) =>
         this.hasVirtualDirectory(directoryName) ? true : undefined,
       realpath: (fileName) => {
-        const normalized = normalizeFileName(fileName)
+        const normalized = path.resolve(fileName)
         if (
           this.activeFiles.has(normalized) ||
           this.hasVirtualDirectory(normalized)
@@ -115,7 +111,7 @@ export class TsgoGenerator implements Generator {
   }
 
   private hasVirtualDirectory(directoryName: string): boolean {
-    const normalized = normalizeFileName(directoryName)
+    const normalized = path.resolve(directoryName)
     const prefix = normalized.endsWith(path.sep)
       ? normalized
       : `${normalized}${path.sep}`
@@ -125,9 +121,7 @@ export class TsgoGenerator implements Generator {
   }
 
   private toTsFilename(fileName: string): string {
-    return normalizeFileName(
-      this.options.languageContext.toTsFilename(fileName),
-    )
+    return path.resolve(this.options.languageContext.toTsFilename(fileName))
   }
 
   private async flushPendingFiles(): Promise<void> {
@@ -223,7 +217,7 @@ export class TsgoGenerator implements Generator {
     for (const [outputFileName, outputFile] of output.outputFiles) {
       if (
         outputFile.sourceFileName &&
-        normalizeFileName(outputFile.sourceFileName) !== tsFileName
+        path.resolve(outputFile.sourceFileName) !== tsFileName
       ) {
         continue
       }

--- a/src/generator/tsgo.ts
+++ b/src/generator/tsgo.ts
@@ -1,10 +1,11 @@
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { createDebug } from 'obug'
-import { loadTsgoApi, type TsgoApiModule } from '../tsgo.ts'
+import { loadTsgoApi } from '../tsgo.ts'
 import type { LanguageContext } from '../custom-language.ts'
 import type { Generator, GeneratorResult } from './index.ts'
 import type { SourceMapInput } from 'rolldown'
+import type * as TsgoApiModule from 'typescript-next/unstable/async'
 import type { API, Snapshot } from 'typescript-next/unstable/async'
 import type { FileSystem } from 'typescript-next/unstable/fs'
 
@@ -21,7 +22,7 @@ export interface TsgoGeneratorOptions {
 
 export class TsgoGenerator implements Generator {
   private options: TsgoGeneratorOptions
-  private apiModule?: TsgoApiModule
+  private apiModule?: typeof TsgoApiModule
   private api?: API
   private snapshot?: Snapshot
   private activeFiles = new Map<string, string>()

--- a/src/generator/tsgo.ts
+++ b/src/generator/tsgo.ts
@@ -1,174 +1,258 @@
-import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { styleText } from 'node:util'
 import { createDebug } from 'obug'
-import { filename_to_dts } from '../filename.ts'
-import { isTS70Installed, require, tryResolve } from '../require.ts'
+import { loadTsgoApi, type TsgoApiModule } from '../tsgo.ts'
 import type { LanguageContext } from '../custom-language.ts'
-import type { Logger } from '../options.ts'
 import type { Generator, GeneratorResult } from './index.ts'
 import type { SourceMapInput } from 'rolldown'
+import type { API, Snapshot } from 'typescript-next/unstable/async'
+import type { FileSystem } from 'typescript-next/unstable/fs'
 
 const debug = createDebug('rolldown-plugin-dts:tsgo')
 
-const spawnAsync = (...args: Parameters<typeof spawn>) =>
-  new Promise<void>((resolve, reject) => {
-    const child = spawn(...args)
-    child.on('close', (code, signal) => {
-      if (code === 0) resolve()
-      else if (signal)
-        reject(new Error(`tsgo process terminated by signal ${signal}`))
-      else reject(new Error(`tsgo process exited with code ${code}`))
-    })
-    child.on('error', (error) => reject(error))
-  })
-
-let tsgoPathCache: string | undefined
-
-export function resolveTsgoPath(logger: Logger): string {
-  if (tsgoPathCache) return tsgoPathCache
-
-  const pkgName = isTS70Installed()
-    ? 'typescript'
-    : '@typescript/native-preview'
-
-  const pkgJsonPath = tryResolve(`${pkgName}/package.json`)
-  if (!pkgJsonPath) {
-    throw new Error(
-      'TypeScript Go is not installed. Please install the `typescript@7.0` or `@typescript/native-preview` package to use the `tsgo` generator.',
-    )
-  }
-
-  const { version } = require(pkgJsonPath) as { version: string }
-  logger.info(
-    `Emit types with ${styleText('underline', `${pkgName}@${version}`)}`,
-  )
-
-  const getExePath: any = require(
-    path.join(path.dirname(pkgJsonPath), 'lib/getExePath.js'),
-  )
-  const tsgoPath = (
-    typeof getExePath === 'function' ? getExePath : getExePath.default
-  )()
-  if (import.meta.TEST) {
-    return tsgoPath
-  }
-  return (tsgoPathCache = tsgoPath)
-}
-
-export interface TsgoContext {
-  path: string
-  dispose: () => Promise<void>
-}
-
 export interface TsgoGeneratorOptions {
-  tsgoPath: string
-  rootDir: string
+  moduleUrl?: string
+  tsgoPath?: string
+  cwd: string
   tsconfig: string
-  sourcemap?: boolean
+  vfs: boolean
   languageContext: LanguageContext
+}
+
+function normalizeFileName(fileName: string): string {
+  return path.resolve(fileName)
 }
 
 export class TsgoGenerator implements Generator {
   private options: TsgoGeneratorOptions
-  private context?: TsgoContext
+  private apiModule?: TsgoApiModule
+  private api?: API
+  private snapshot?: Snapshot
+  private activeFiles = new Map<string, string>()
+  private pendingFiles = new Map<string, string>()
+  private openedFiles = new Set<string>()
+  private emitQueue: Promise<void> = Promise.resolve()
 
   constructor(options: TsgoGeneratorOptions) {
     this.options = options
   }
 
   async init(): Promise<void> {
-    const { tsgoPath, rootDir, tsconfig, sourcemap } = this.options
-    this.context = await runTsgo(tsgoPath, rootDir, tsconfig, sourcemap)
+    this.activeFiles.clear()
+    this.pendingFiles.clear()
+    this.openedFiles.clear()
+    this.emitQueue = Promise.resolve()
+
+    this.apiModule = await loadTsgoApi(this.options.moduleUrl)
+    const { tsgoPath, cwd, tsconfig, vfs } = this.options
+    const fs = vfs ? this.createFileSystem() : undefined
+    this.api = new this.apiModule.API({
+      cwd,
+      ...(tsgoPath ? { tsserverPath: tsgoPath } : undefined),
+      ...(fs ? { fs } : undefined),
+    })
+    this.snapshot = await this.api.updateSnapshot({
+      openProjects: [tsconfig],
+    })
   }
 
-  async emit(_code: string, fileName: string): Promise<GeneratorResult> {
-    const { rootDir, languageContext } = this.options
-    if (languageContext.isCustomLanguageFile(fileName)) {
-      return {
-        error: `tsgo does not support ${path.extname(fileName)} files.`,
-      }
+  addFile(code: string, fileName: string): void {
+    if (!this.options.vfs) return
+    this.pendingFiles.set(this.toTsFilename(fileName), code)
+  }
+
+  emit(code: string, fileName: string): Promise<GeneratorResult> {
+    if (!this.options.vfs) {
+      return this.emitFromSnapshot(fileName)
     }
-    if (!this.context) {
+
+    this.addFile(code, fileName)
+    const result = this.emitQueue.then(async () => {
+      await this.flushPendingFiles()
+      return this.emitFromSnapshot(fileName)
+    })
+    this.emitQueue = result.then(
+      () => {},
+      () => {},
+    )
+    return result
+  }
+
+  async dispose(): Promise<void> {
+    await this.emitQueue
+    const snapshot = this.snapshot
+    const api = this.api
+    this.apiModule = undefined
+    this.api = undefined
+    this.snapshot = undefined
+    try {
+      await snapshot?.dispose()
+    } finally {
+      await api?.close()
+    }
+    this.activeFiles.clear()
+    this.pendingFiles.clear()
+    this.openedFiles.clear()
+  }
+
+  private createFileSystem(): FileSystem {
+    return {
+      readFile: (fileName) => this.activeFiles.get(normalizeFileName(fileName)),
+      fileExists: (fileName) =>
+        this.activeFiles.has(normalizeFileName(fileName)) ? true : undefined,
+      directoryExists: (directoryName) =>
+        this.hasVirtualDirectory(directoryName) ? true : undefined,
+      realpath: (fileName) => {
+        const normalized = normalizeFileName(fileName)
+        if (
+          this.activeFiles.has(normalized) ||
+          this.hasVirtualDirectory(normalized)
+        ) {
+          return normalized
+        }
+      },
+    }
+  }
+
+  private hasVirtualDirectory(directoryName: string): boolean {
+    const normalized = normalizeFileName(directoryName)
+    const prefix = normalized.endsWith(path.sep)
+      ? normalized
+      : `${normalized}${path.sep}`
+    return this.activeFiles
+      .keys()
+      .some((fileName) => fileName.startsWith(prefix))
+  }
+
+  private toTsFilename(fileName: string): string {
+    return normalizeFileName(
+      this.options.languageContext.toTsFilename(fileName),
+    )
+  }
+
+  private async flushPendingFiles(): Promise<void> {
+    if (!this.pendingFiles.size) return
+    if (!this.api || !this.snapshot) {
       throw new Error('TsgoGenerator has not been initialized.')
     }
 
-    const dtsPath = path.resolve(
-      this.context.path,
-      path.relative(
-        path.resolve(rootDir),
-        filename_to_dts(fileName, languageContext),
-      ),
-    )
-    if (!existsSync(dtsPath)) {
-      debug('[tsgo]', dtsPath, 'is missing')
+    const entries = [...this.pendingFiles]
+    this.pendingFiles.clear()
+
+    const previous = new Map<string, string | undefined>()
+    const created: string[] = []
+    const changed: string[] = []
+    const openFiles: string[] = []
+
+    for (const [fileName, code] of entries) {
+      const hadVirtualFile = this.activeFiles.has(fileName)
+      previous.set(fileName, this.activeFiles.get(fileName))
+      this.activeFiles.set(fileName, code)
+
+      if (hadVirtualFile || existsSync(fileName)) changed.push(fileName)
+      else created.push(fileName)
+
+      if (!this.openedFiles.has(fileName)) openFiles.push(fileName)
+    }
+
+    let nextSnapshot: Snapshot
+    try {
+      nextSnapshot = await this.api.updateSnapshot({
+        fileChanges: {
+          ...(created.length ? { created } : undefined),
+          ...(changed.length ? { changed } : undefined),
+        },
+        ...(openFiles.length ? { openFiles } : undefined),
+      })
+    } catch (error) {
+      for (const [fileName, code] of entries) {
+        const oldCode = previous.get(fileName)
+        if (oldCode === undefined) this.activeFiles.delete(fileName)
+        else this.activeFiles.set(fileName, oldCode)
+        if (!this.pendingFiles.has(fileName)) {
+          this.pendingFiles.set(fileName, code)
+        }
+      }
+      throw error
+    }
+
+    for (const fileName of openFiles) this.openedFiles.add(fileName)
+    const oldSnapshot = this.snapshot
+    this.snapshot = nextSnapshot
+    await oldSnapshot.dispose()
+  }
+
+  private async emitFromSnapshot(fileName: string): Promise<GeneratorResult> {
+    if (!this.apiModule || !this.api || !this.snapshot) {
+      throw new Error('TsgoGenerator has not been initialized.')
+    }
+
+    const tsFileName = this.toTsFilename(fileName)
+    const project = await this.snapshot
+      .getDefaultProjectForFile(tsFileName)
+      .catch((error: unknown) => {
+        throw new Error(this.mapError(error, tsFileName, fileName), {
+          cause: error,
+        })
+      })
+    if (!project) {
       return {
-        error: `tsgo did not generate dts file for ${fileName}, please check your tsconfig.`,
+        error: `No TypeScript Go project found for ${fileName}. Please check your tsconfig and custom language filename mapping.`,
       }
     }
 
-    const code = await readFile(dtsPath, 'utf8')
+    const output = await project.program
+      .getDeclarationEmit([tsFileName])
+      .catch((error: unknown) => {
+        throw new Error(this.mapError(error, tsFileName, fileName), {
+          cause: error,
+        })
+      })
+    if (output.emitSkipped && output.diagnostics.length) {
+      return {
+        error: this.mapError(
+          this.apiModule.formatDiagnostics(output.diagnostics, this.api),
+          tsFileName,
+          fileName,
+        ),
+      }
+    }
+
+    let code: string | undefined
     let map: SourceMapInput | undefined
-    const mapPath = `${dtsPath}.map`
-    if (existsSync(mapPath)) {
-      const mapRaw = await readFile(mapPath, 'utf8')
-      map = {
-        ...JSON.parse(mapRaw),
-        sources: [fileName],
+    for (const [outputFileName, outputFile] of output.outputFiles) {
+      if (
+        outputFile.sourceFileName &&
+        normalizeFileName(outputFile.sourceFileName) !== tsFileName
+      ) {
+        continue
+      }
+
+      if (outputFileName.endsWith('.map')) {
+        map = {
+          ...JSON.parse(outputFile.text),
+          sources: [fileName],
+        }
+      } else {
+        code = outputFile.text
+      }
+    }
+
+    if (!code) {
+      debug('[tsgo] declaration output is missing for', tsFileName)
+      return {
+        error: `tsgo did not generate a declaration file for ${fileName}. Please check your tsconfig.`,
       }
     }
 
     return { code, map }
   }
 
-  async dispose(): Promise<void> {
-    await this.context?.dispose()
-    this.context = undefined
-  }
-}
-
-export async function runTsgo(
-  tsgoPath: string,
-  rootDir: string,
-  tsconfig: string,
-  sourcemap?: boolean,
-): Promise<TsgoContext> {
-  debug('[tsgo] rootDir', rootDir)
-  debug('[tsgo] using tsgo binary', tsgoPath)
-
-  const tsgoDist = await mkdtemp(path.join(tmpdir(), 'rolldown-plugin-dts-'))
-  debug('[tsgo] tsgoDist', tsgoDist)
-
-  const args = [
-    '--noEmit',
-    'false',
-    '--declaration',
-    '--emitDeclarationOnly',
-    '-p',
-    tsconfig,
-    '--outDir',
-    tsgoDist,
-    '--rootDir',
-    rootDir,
-    '--noCheck',
-    ...(sourcemap ? ['--declarationMap'] : []),
-  ]
-  debug('[tsgo] args %o', args)
-
-  await spawnAsync(tsgoPath, args, { stdio: 'inherit' })
-
-  return {
-    path: tsgoDist,
-    async dispose() {
-      if (debug.enabled) {
-        debug('[tsgo] skip cleanup of tsgoDist', tsgoDist)
-      } else {
-        debug('[tsgo] disposing tsgoDist', tsgoDist)
-        await rm(tsgoDist, { recursive: true, force: true }).catch(() => {})
-      }
-    },
+  private mapError(
+    error: unknown,
+    tsFileName: string,
+    fileName: string,
+  ): string {
+    return String(error).replaceAll(tsFileName, fileName)
   }
 }

--- a/src/generator/tsgo.ts
+++ b/src/generator/tsgo.ts
@@ -44,8 +44,8 @@ export class TsgoGenerator implements Generator {
     const fs = vfs ? this.createFileSystem() : undefined
     this.api = new this.apiModule.API({
       cwd,
-      ...(tsgoPath ? { tsserverPath: tsgoPath } : undefined),
-      ...(fs ? { fs } : undefined),
+      tsserverPath: tsgoPath,
+      fs,
     })
     this.snapshot = await this.api.updateSnapshot({
       openProjects: [tsconfig],
@@ -76,19 +76,8 @@ export class TsgoGenerator implements Generator {
 
   async dispose(): Promise<void> {
     await this.emitQueue
-    const snapshot = this.snapshot
-    const api = this.api
-    this.apiModule = undefined
-    this.api = undefined
-    this.snapshot = undefined
-    try {
-      await snapshot?.dispose()
-    } finally {
-      await api?.close()
-    }
-    this.activeFiles.clear()
-    this.pendingFiles.clear()
-    this.openedFiles.clear()
+    await this.api?.close()
+    this.api = this.snapshot = undefined
   }
 
   private createFileSystem(): FileSystem {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@ import { createDebug } from 'obug'
 import { createDtsInputPlugin } from './dts-input.ts'
 import { createFakeJsPlugin } from './fake-js/index.ts'
 import { createGeneratePlugin } from './generate.ts'
-import { resolveOptions, type Logger, type Options } from './options.ts'
+import {
+  resolveOptions,
+  type Logger,
+  type Options,
+  type TscOptions,
+} from './options.ts'
 import { createDtsResolvePlugin } from './resolver.ts'
 import type { Plugin } from 'rolldown'
 
@@ -29,6 +34,7 @@ export {
   resolveOptions,
   type Logger,
   type Options,
+  type TscOptions,
 }
 export type { CustomLanguage } from './custom-language.ts'
 export type { Generator, GeneratorResult } from './generator/index.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,3 +31,4 @@ export {
   type Options,
 }
 export type { CustomLanguage } from './custom-language.ts'
+export type { Generator, GeneratorResult } from './generator/index.ts'

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,9 +11,9 @@ import { LanguageContext, type CustomLanguage } from './custom-language.ts'
 import { requireTSApi } from './require.ts'
 import { createVueLanguage, type VueLanguageOptions } from './tsc/vue.ts'
 import {
-  getDefaultTsgoGenerator,
   getDefaultTsgoModuleUrl,
-  resolveTsgoApiPackage,
+  getTsgoPackageInfo,
+  loadTsgoApi,
 } from './tsgo.ts'
 import type { IsolatedDeclarationsOptions } from 'rolldown/experimental'
 
@@ -337,7 +337,8 @@ export function resolveOptions({
 
   oxc ||= {}
   tsgo ||= {}
-  tsgo.moduleUrl ??= getDefaultTsgoModuleUrl()
+  const defaultTsgoModuleUrl = getDefaultTsgoModuleUrl()
+  tsgo.moduleUrl ??= defaultTsgoModuleUrl
   tsgo.vfs ??= false
 
   if (isUsingVolar) {
@@ -357,7 +358,12 @@ export function resolveOptions({
     if (compilerOptions.isolatedDeclarations) {
       generator = 'oxc'
     } else {
-      generator = getDefaultTsgoGenerator() ?? 'tsc'
+      const pkg = getTsgoPackageInfo(defaultTsgoModuleUrl)
+      generator =
+        pkg &&
+        (pkg.api?.Program?.prototype.getDeclarationEmit || !pkg.hasClassicApi)
+          ? 'tsgo'
+          : 'tsc'
     }
   }
 
@@ -389,7 +395,7 @@ export function resolveOptions({
         'TypeScript Go is experimental. Some options will be unavailable.',
       )
     }
-    resolveTsgoApiPackage(logger, tsgo.moduleUrl)
+    loadTsgoApi(tsgo.moduleUrl, logger)
   }
   oxc.stripInternal ??= !!compilerOptions.stripInternal
   // @ts-expect-error omitted in user options

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,6 +15,7 @@ import {
   getTsgoPackageInfo,
   loadTsgoApi,
 } from './tsgo.ts'
+import type { Generator } from './generator/index.ts'
 import type { IsolatedDeclarationsOptions } from 'rolldown/experimental'
 
 const debug = createDebug('rolldown-plugin-dts:options')
@@ -34,6 +35,7 @@ export interface GeneralOptions {
    * - `'oxc'` is faster but requires code compatible with
    *   [`isolatedDeclarations`](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations).
    * - `'tsgo'` uses the experimental TypeScript Go API.
+   * - A custom {@link Generator} implementation can be provided directly.
    *
    * When omitted, the plugin selects `'oxc'` for `isolatedDeclarations`,
    * `'tsgo'` when TypeScript exposes the declaration emit API, and `'tsc'`
@@ -41,7 +43,7 @@ export interface GeneralOptions {
    *
    * @default Inferred from the TypeScript configuration and installed compiler.
    */
-  generator?: 'tsc' | 'oxc' | 'tsgo'
+  generator?: 'tsc' | 'oxc' | 'tsgo' | Generator
 
   /**
    * Glob pattern(s) that select source files for declaration generation.

--- a/src/options.ts
+++ b/src/options.ts
@@ -8,9 +8,13 @@ import {
 } from 'get-tsconfig'
 import { createDebug } from 'obug'
 import { LanguageContext, type CustomLanguage } from './custom-language.ts'
-import { resolveTsgoPath } from './generator/tsgo.ts'
-import { isTS70Installed, requireTSApi } from './require.ts'
+import { requireTSApi } from './require.ts'
 import { createVueLanguage, type VueLanguageOptions } from './tsc/vue.ts'
+import {
+  getDefaultTsgoGenerator,
+  getDefaultTsgoModuleUrl,
+  resolveTsgoApiPackage,
+} from './tsgo.ts'
 import type { IsolatedDeclarationsOptions } from 'rolldown/experimental'
 
 const debug = createDebug('rolldown-plugin-dts:options')
@@ -29,11 +33,12 @@ export interface GeneralOptions {
    * - `'tsc'` supports the full TypeScript type system.
    * - `'oxc'` is faster but requires code compatible with
    *   [`isolatedDeclarations`](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations).
-   * - `'tsgo'` uses the experimental TypeScript Go compiler.
+   * - `'tsgo'` uses the experimental TypeScript Go API.
    *
    * When omitted, the plugin selects `'oxc'` for `isolatedDeclarations`,
-   * `'tsgo'` for TypeScript 7, and `'tsc'` otherwise. Volar-based custom
-   * languages require `'tsc'`.
+   * `'tsgo'` for native TypeScript versions, and `'tsc'` otherwise. Native
+   * TypeScript installations without the declaration emit API are rejected.
+   * Volar-based custom languages require `'tsc'`.
    *
    * @default Inferred from the TypeScript configuration and installed compiler.
    */
@@ -202,10 +207,7 @@ export interface Options extends GeneralOptions, TscOptions {
   //#region TypeScript Go
 
   /**
-   * **[Experimental]** Options for the `tsgo` generator.
-   *
-   * Used when {@link GeneralOptions.generator generator} is `'tsgo'` or
-   * TypeScript 7 is detected.
+   * **[Experimental]** Options for the TypeScript Go generator.
    */
   tsgo?: TsgoOptions
 
@@ -215,7 +217,8 @@ export interface Options extends GeneralOptions, TscOptions {
    * If a language is supported via {@link https://volarjs.dev Volar},
    * {@link CustomLanguage.volarTypeScript} and
    * {@link CustomLanguage.createVolarPlugins} are both required. Volar
-   * languages require `tsc`; `tsgo` does not support custom languages.
+   * languages require `tsc`. Non-Volar languages can use `tsgo` together
+   * with {@link TsgoOptions.vfs `tsgo.vfs`}.
    *
    * @experimental
    */
@@ -223,8 +226,28 @@ export interface Options extends GeneralOptions, TscOptions {
 }
 
 export interface TsgoOptions {
-  /** Path to a custom `tsgo` executable. */
+  /**
+   * URL of the TypeScript module that provides the TypeScript Go API.
+   *
+   * Use `import.meta.resolve()` to select an npm alias or another compatible
+   * TypeScript module.
+   *
+   * @default import.meta.resolve('typescript')
+   */
+  moduleUrl?: string
+
+  /**
+   * Path passed to the TypeScript Go API as `tsserverPath`.
+   */
   path?: string
+
+  /**
+   * Supplies Rolldown-transformed source code to the `tsgo` API through a
+   * virtual filesystem.
+   *
+   * @default false
+   */
+  vfs?: boolean
 }
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
@@ -301,48 +324,53 @@ export function resolveOptions({
 
   customLanguages ||= []
   if (vue) {
+    if (generator && generator !== 'tsc') {
+      throw new Error(
+        'Volar-based custom languages (including the `vue` option) require the `tsc` generator.',
+      )
+    }
     customLanguages.push(createVueLanguage(typeof vue === 'object' ? vue : {}))
   }
 
   const languageContext = new LanguageContext(customLanguages)
-  if (customLanguages.length) {
-    // Custom languages that rely on Volar can only be handled by the `tsc`
-    // generator; Volar-free languages also work with `oxc`, but `tsgo` does not
-    // support custom languages at all.
-    if (languageContext.isUsingVolar()) {
-      requireTSApi(
-        'custom languages',
-        '. Custom languages (including the `vue` option) require the TypeScript API.',
-      )
+  const isUsingVolar = languageContext.isUsingVolar()
 
-      if (generator && generator !== 'tsc') {
-        throw new Error(
-          'Volar-based custom languages (including the `vue` option) require the `tsc` generator.',
-        )
-      }
-      generator = 'tsc'
-    } else if (generator === 'tsgo') {
-      throw new Error('The `tsgo` generator does not support custom languages.')
+  oxc ||= {}
+  tsgo ||= {}
+  tsgo.moduleUrl ??= getDefaultTsgoModuleUrl()
+  tsgo.vfs ??= false
+
+  if (isUsingVolar) {
+    if (generator && generator !== 'tsc') {
+      throw new Error(
+        'Volar-based custom languages (including the `vue` option) require the `tsc` generator.',
+      )
     }
+    requireTSApi(
+      'custom languages',
+      '. Custom languages require the TypeScript API.',
+    )
+    generator = 'tsc'
   }
 
   if (!generator) {
     if (compilerOptions.isolatedDeclarations) {
       generator = 'oxc'
-    } else if (isTS70Installed()) {
-      if (customLanguages.length) {
-        throw new Error(
-          "TypeScript 7.0 is installed, but the `tsgo` generator does not support custom languages. Enable `isolatedDeclarations` or set `generator: 'oxc'` to use Oxc instead, or install TypeScript 6.0 or below.",
-        )
-      }
-      generator = 'tsgo'
     } else {
-      generator = 'tsc'
+      generator = getDefaultTsgoGenerator() ?? 'tsc'
     }
   }
 
-  oxc ||= {}
-  tsgo ||= {}
+  if (
+    customLanguages.length &&
+    !isUsingVolar &&
+    generator === 'tsgo' &&
+    !tsgo.vfs
+  ) {
+    throw new Error(
+      "The `tsgo` generator requires `tsgo.vfs: true` to process custom languages. Enable VFS, use `generator: 'oxc'`, or use a compatible `tsc` installation.",
+    )
+  }
 
   if (generator === 'tsc') {
     requireTSApi(
@@ -358,10 +386,10 @@ export function resolveOptions({
     if (!warnedTsgo) {
       warnedTsgo = true
       logger.warn(
-        'TypeScript 7.0 does not yet have a stable API and is experimental. Some options will be unavailable.',
+        'TypeScript Go is experimental. Some options will be unavailable.',
       )
     }
-    tsgo.path ??= resolveTsgoPath(logger)
+    resolveTsgoApiPackage(logger, tsgo.moduleUrl)
   }
   oxc.stripInternal ??= !!compilerOptions.stripInternal
   // @ts-expect-error omitted in user options

--- a/src/options.ts
+++ b/src/options.ts
@@ -36,9 +36,8 @@ export interface GeneralOptions {
    * - `'tsgo'` uses the experimental TypeScript Go API.
    *
    * When omitted, the plugin selects `'oxc'` for `isolatedDeclarations`,
-   * `'tsgo'` for native TypeScript versions, and `'tsc'` otherwise. Native
-   * TypeScript installations without the declaration emit API are rejected.
-   * Volar-based custom languages require `'tsc'`.
+   * `'tsgo'` when TypeScript exposes the declaration emit API, and `'tsc'`
+   * otherwise. Volar-based custom languages require `'tsc'`.
    *
    * @default Inferred from the TypeScript configuration and installed compiler.
    */
@@ -359,11 +358,7 @@ export function resolveOptions({
       generator = 'oxc'
     } else {
       const pkg = getTsgoPackageInfo(defaultTsgoModuleUrl)
-      generator =
-        pkg &&
-        (pkg.api?.Program?.prototype.getDeclarationEmit || !pkg.hasClassicApi)
-          ? 'tsgo'
-          : 'tsc'
+      generator = pkg?.hasTsgoApi ? 'tsgo' : 'tsc'
     }
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,7 +9,11 @@ import {
 import { createDebug } from 'obug'
 import { LanguageContext, type CustomLanguage } from './custom-language.ts'
 import { requireTSApi } from './require.ts'
-import { createVueLanguage, type VueLanguageOptions } from './tsc/vue.ts'
+import {
+  createVueLanguage,
+  createVueLanguageMetadata,
+  type VueLanguageOptions,
+} from './tsc/vue.ts'
 import {
   getDefaultTsgoModuleUrl,
   getTsgoPackageInfo,
@@ -164,6 +168,8 @@ export interface TscOptions {
 
   /**
    * Runs `tsc` or `vue-tsc` in a separate process.
+   * Custom languages supplied through {@link Options.customLanguages} are not
+   * supported in the worker process.
    *
    * @default false
    */
@@ -262,6 +268,7 @@ export type OptionsResolved = Overwrite<
     tsconfigRaw: TsconfigJson
     tsgo: TsgoOptions
     languageContext: LanguageContext
+    vue: false | VueLanguageOptions
   }
 >
 
@@ -323,18 +330,26 @@ export function resolveOptions({
     compilerOptions,
   }
 
-  customLanguages ||= []
-  if (vue) {
+  const hasCustomLanguages = !!customLanguages?.length
+  customLanguages = [...(customLanguages || [])]
+  const vueOptions: false | VueLanguageOptions = vue
+    ? typeof vue === 'object'
+      ? vue
+      : {}
+    : false
+  if (vueOptions) {
     if (generator && generator !== 'tsc') {
       throw new Error(
         'Volar-based custom languages (including the `vue` option) require the `tsc` generator.',
       )
     }
-    customLanguages.push(createVueLanguage(typeof vue === 'object' ? vue : {}))
+    customLanguages.push(
+      parallel ? createVueLanguageMetadata() : createVueLanguage(vueOptions),
+    )
   }
 
   const languageContext = new LanguageContext(customLanguages)
-  const isUsingVolar = languageContext.isUsingVolar()
+  const isUsingVolar = !!vueOptions || languageContext.isUsingVolar()
 
   oxc ||= {}
   tsgo ||= {}
@@ -348,10 +363,6 @@ export function resolveOptions({
         'Volar-based custom languages (including the `vue` option) require the `tsc` generator.',
       )
     }
-    requireTSApi(
-      'custom languages',
-      '. Custom languages require the TypeScript API.',
-    )
     generator = 'tsc'
   }
 
@@ -362,6 +373,19 @@ export function resolveOptions({
       const pkg = getTsgoPackageInfo(defaultTsgoModuleUrl)
       generator = pkg?.hasTsgoApi ? 'tsgo' : 'tsc'
     }
+  }
+
+  if (generator === 'tsc' && parallel && hasCustomLanguages) {
+    throw new Error(
+      'The `parallel` option does not support `customLanguages`. Disable `parallel` or use the built-in `vue` option for Vue.',
+    )
+  }
+
+  if (isUsingVolar) {
+    requireTSApi(
+      vueOptions ? 'Vue' : 'custom languages',
+      vueOptions ? '.' : '. Custom languages require the TypeScript API.',
+    )
   }
 
   if (
@@ -422,6 +446,7 @@ export function resolveOptions({
     // tsc
     build,
     incremental,
+    vue: vueOptions,
     parallel,
     eager,
     newContext,

--- a/src/options.ts
+++ b/src/options.ts
@@ -30,8 +30,7 @@ export interface Logger {
   error: (...args: any[]) => void
 }
 
-//#region General Options
-export interface GeneralOptions {
+export interface Options {
   /**
    * The generator used to produce declaration files.
    *
@@ -137,9 +136,54 @@ export interface GeneralOptions {
    * @default console
    */
   logger?: Logger
+
+  /**
+   * Registers the built-in Vue language integration using `vue-tsc`.
+   *
+   * This is a shortcut for a preconfigured {@link Options.customLanguages}
+   * entry and requires the `tsc` generator.
+   *
+   * @default false
+   */
+  vue?: boolean | VueLanguageOptions
+
+  /**
+   * Generates declarations for JavaScript files with JSDoc types.
+   *
+   * @default Enabled when `allowJs` or `checkJs` is set.
+   */
+  emitJs?: boolean
+
+  /** Options for the built-in `tsc` generator. */
+  tsc?: TscOptions
+
+  /**
+   * Options for the `oxc` generator.
+   *
+   * The top-level {@link Options.sourcemap sourcemap} option controls
+   * declaration maps.
+   */
+  oxc?: Omit<IsolatedDeclarationsOptions, 'sourcemap'>
+
+  /**
+   * **[Experimental]** Options for the TypeScript Go generator.
+   */
+  tsgo?: TsgoOptions
+
+  /**
+   * Registers non-standard source languages such as Vue or Astro.
+   *
+   * If a language is supported via {@link https://volarjs.dev Volar},
+   * {@link CustomLanguage.volarTypeScript} and
+   * {@link CustomLanguage.createVolarPlugins} are both required. Volar
+   * languages require `tsc`. Non-Volar languages can use `tsgo` together
+   * with {@link TsgoOptions.vfs `tsgo.vfs`}.
+   *
+   * @experimental
+   */
+  customLanguages?: CustomLanguage[]
 }
 
-//#region tsc Options
 export interface TscOptions {
   /**
    * Uses TypeScript build mode (`tsc -b`) and follows project references.
@@ -155,16 +199,6 @@ export interface TscOptions {
    * @default Enabled when the config sets `incremental` or `tsBuildInfoFile`.
    */
   incremental?: boolean
-
-  /**
-   * Registers the built-in Vue language integration using `vue-tsc`.
-   *
-   * This is a shortcut for a preconfigured {@link Options.customLanguages}
-   * entry and requires the `tsc` generator.
-   *
-   * @default false
-   */
-  vue?: boolean | VueLanguageOptions
 
   /**
    * Runs `tsc` or `vue-tsc` in a separate process.
@@ -190,46 +224,6 @@ export interface TscOptions {
    * @default false
    */
   newContext?: boolean
-
-  /**
-   * Generates declarations for JavaScript files with JSDoc types.
-   *
-   * @default Enabled when `allowJs` or `checkJs` is set.
-   */
-  emitJs?: boolean
-}
-
-/** Configuration accepted by {@link dts}. */
-export interface Options extends GeneralOptions, TscOptions {
-  //#region Oxc
-
-  /**
-   * Options for the `oxc` generator.
-   *
-   * The top-level {@link GeneralOptions.sourcemap sourcemap} option controls
-   * declaration maps.
-   */
-  oxc?: Omit<IsolatedDeclarationsOptions, 'sourcemap'>
-
-  //#region TypeScript Go
-
-  /**
-   * **[Experimental]** Options for the TypeScript Go generator.
-   */
-  tsgo?: TsgoOptions
-
-  /**
-   * Registers non-standard source languages such as Vue or Astro.
-   *
-   * If a language is supported via {@link https://volarjs.dev Volar},
-   * {@link CustomLanguage.volarTypeScript} and
-   * {@link CustomLanguage.createVolarPlugins} are both required. Volar
-   * languages require `tsc`. Non-Volar languages can use `tsgo` together
-   * with {@link TsgoOptions.vfs `tsgo.vfs`}.
-   *
-   * @experimental
-   */
-  customLanguages?: CustomLanguage[]
 }
 
 export interface TsgoOptions {
@@ -260,7 +254,9 @@ export interface TsgoOptions {
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 
 export type OptionsResolved = Overwrite<
-  Required<Omit<Options, 'compilerOptions' | 'vue' | 'customLanguages'>>,
+  Required<
+    Omit<Options, 'compilerOptions' | 'vue' | 'customLanguages' | 'tsc'>
+  >,
   {
     entry?: string[]
     tsconfig?: string
@@ -269,6 +265,7 @@ export type OptionsResolved = Overwrite<
     tsgo: TsgoOptions
     languageContext: LanguageContext
     vue: false | VueLanguageOptions
+    tsc: Required<TscOptions>
   }
 >
 
@@ -289,14 +286,9 @@ export function resolveOptions({
   sideEffects = false,
   logger = console,
   customLanguages,
+  tsc,
 
-  // tsc
-  build = false,
-  incremental = false,
   vue = false,
-  parallel = false,
-  eager = false,
-  newContext = false,
   emitJs,
 
   oxc,
@@ -319,8 +311,6 @@ export function resolveOptions({
     ...compilerOptions,
   }
 
-  incremental ||=
-    compilerOptions.incremental || !!compilerOptions.tsBuildInfoFile
   sourcemap ??= !!compilerOptions.declarationMap
   compilerOptions.declarationMap = sourcemap
 
@@ -328,6 +318,16 @@ export function resolveOptions({
     ...resolvedTsconfig,
     ...overriddenTsconfigRaw,
     compilerOptions,
+  }
+
+  const tscOptions: Required<TscOptions> = {
+    build: tsc?.build ?? false,
+    incremental:
+      tsc?.incremental ??
+      !!(compilerOptions.incremental || compilerOptions.tsBuildInfoFile),
+    parallel: tsc?.parallel ?? false,
+    eager: tsc?.eager ?? false,
+    newContext: tsc?.newContext ?? false,
   }
 
   const hasCustomLanguages = !!customLanguages?.length
@@ -344,7 +344,9 @@ export function resolveOptions({
       )
     }
     customLanguages.push(
-      parallel ? createVueLanguageMetadata() : createVueLanguage(vueOptions),
+      tscOptions.parallel
+        ? createVueLanguageMetadata()
+        : createVueLanguage(vueOptions),
     )
   }
 
@@ -375,9 +377,9 @@ export function resolveOptions({
     }
   }
 
-  if (generator === 'tsc' && parallel && hasCustomLanguages) {
+  if (generator === 'tsc' && tscOptions.parallel && hasCustomLanguages) {
     throw new Error(
-      'The `parallel` option does not support `customLanguages`. Disable `parallel` or use the built-in `vue` option for Vue.',
+      'The `tsc.parallel` option does not support `customLanguages`. Disable `tsc.parallel` or use the built-in `vue` option for Vue.',
     )
   }
 
@@ -443,13 +445,8 @@ export function resolveOptions({
     cjsDefault,
     sideEffects,
 
-    // tsc
-    build,
-    incremental,
     vue: vueOptions,
-    parallel,
-    eager,
-    newContext,
+    tsc: tscOptions,
     emitJs,
     languageContext,
 

--- a/src/require.ts
+++ b/src/require.ts
@@ -15,23 +15,42 @@ export const require: NodeJS.Require = import.meta.TEST
 
 const debug = createDebug('rolldown-plugin-dts:utils')
 
-function tryRequire<T>(moduleName: string): T | undefined {
+export function tryRequire<T>(moduleName: string): T | undefined {
   try {
     return require(moduleName)
   } catch {}
 }
 
-export function tryResolve(id: string): string | undefined {
+export function tryResolve(
+  id: string,
+  options?: { paths?: string[] },
+): string | undefined {
   try {
-    return require.resolve(id)
+    return require.resolve(id, options)
   } catch {}
 }
 
 let _ts: typeof import('typescript') | undefined
 
-export function isTS70Installed(): boolean {
-  const tsPkg = tryRequire<{ version: string }>('typescript/package.json')
-  return tsPkg?.version.slice(0, 3) === '7.0'
+export interface PackageInfo {
+  name: string
+  version: string
+  packageJsonPath: string
+}
+
+export function getPackageInfo(name: string): PackageInfo | undefined {
+  const packageJsonPath = tryResolve(`${name}/package.json`)
+  if (!packageJsonPath) return
+
+  const pkg = tryRequire<{ version?: string }>(packageJsonPath)
+  if (!pkg?.version) return
+
+  return { name, version: pkg.version, packageJsonPath }
+}
+
+export function isNativeTypeScriptVersion(version: string): boolean {
+  const major = +version.split('.', 1)[0]
+  return Number.isFinite(major) && major >= 7
 }
 
 export function requireTSApi(
@@ -40,9 +59,10 @@ export function requireTSApi(
 ): typeof import('typescript') {
   if (_ts) return _ts
 
-  if (isTS70Installed()) {
+  const tsPkg = getPackageInfo('typescript')
+  if (tsPkg && isNativeTypeScriptVersion(tsPkg.version)) {
     throw new Error(
-      `TypeScript 7.0 is not supported when using ${mode}. Please use TypeScript 6.0 or below${message}`,
+      `TypeScript ${tsPkg.version} does not provide the classic TypeScript API required by ${mode}. Please use TypeScript 6.0 or below${message}`,
     )
   }
 
@@ -51,7 +71,7 @@ export function requireTSApi(
     ts = require('typescript')
   } catch (cause) {
     throw new Error(
-      `TypeScript is not installed. Please install the \`typescript\` package (v7.0 is not yet supported)${
+      `TypeScript is not installed. Please install the \`typescript\` package (v6.0 or below for the classic API)${
         message
       }`,
       { cause },

--- a/src/tsc/emit-compiler.ts
+++ b/src/tsc/emit-compiler.ts
@@ -139,7 +139,7 @@ function createTsProgramFromParsedConfig({
 
     if (hasReferences) {
       throw new Error(
-        `[rolldown-plugin-dts] Unable to load ${id}; You have "references" in your tsconfig file. Perhaps you want to add \`dts: { build: true }\` in your config?`,
+        `[rolldown-plugin-dts] Unable to load ${id}; You have "references" in your tsconfig file. Perhaps you want to add \`dts: { tsc: { build: true } }\` in your config?`,
       )
     }
 
@@ -204,7 +204,7 @@ export function tscEmitCompiler(tscOptions: TscOptions): TscResult {
       dtsCode = file.getFullText()
     } else {
       console.warn(
-        '[rolldown-plugin-dts] Warning: Failed to emit declaration file. Please try to enable `eager` option (`dts.eager` for tsdown).',
+        '[rolldown-plugin-dts] Warning: Failed to emit declaration file. Please try to enable `tsc.eager` option (`dts.tsc.eager` for tsdown).',
       )
     }
   }

--- a/src/tsc/vue.ts
+++ b/src/tsc/vue.ts
@@ -11,6 +11,22 @@ export interface VueLanguageOptions {
   vueCompilerOptions?: Partial<import('@vue/language-core').VueCompilerOptions>
 }
 
+export function createVueLanguageMetadata(): CustomLanguage {
+  return {
+    extensionPatterns: [RE_VUE],
+    tsFileExtensionInfos: [
+      {
+        extension: 'vue',
+        isMixedContent: true,
+        scriptKind: 7 satisfies ts.ScriptKind.Deferred,
+      },
+    ],
+    toTsFilename(id: string): string {
+      return id.replace(RE_VUE, '.vue.ts')
+    },
+  }
+}
+
 export function createVueLanguage(
   userOptions: VueLanguageOptions = {},
 ): CustomLanguage {
@@ -44,20 +60,10 @@ export function createVueLanguage(
   }
 
   return {
-    extensionPatterns: [RE_VUE],
-    tsFileExtensionInfos: [
-      {
-        extension: 'vue',
-        isMixedContent: true,
-        scriptKind: 7 satisfies ts.ScriptKind.Deferred,
-      },
-    ],
+    ...createVueLanguageMetadata(),
     volarTypeScript,
     createVolarPlugins(ts, options) {
       return [getLanguagePlugin(ts, options)]
-    },
-    toTsFilename(id: string): string {
-      return id.replace(RE_VUE, '.vue.ts')
     },
   }
 }

--- a/src/tsc/worker.ts
+++ b/src/tsc/worker.ts
@@ -1,10 +1,14 @@
 import process from 'node:process'
 import { LanguageContext } from '../custom-language.ts'
+import { createVueLanguage, type VueLanguageOptions } from './vue.ts'
 import { tscEmit, type TscOptions, type TscResult } from './index.ts'
+
+export type WorkerTscOptions = Omit<TscOptions, 'context' | 'languageContext'>
 
 export interface WorkerRequest {
   id: number
-  options: TscOptions
+  options: WorkerTscOptions
+  vue?: VueLanguageOptions
 }
 
 export interface WorkerResponse {
@@ -13,15 +17,17 @@ export interface WorkerResponse {
   error?: unknown
 }
 
+let languageContext: LanguageContext | undefined
+
 process.on('message', (request: WorkerRequest) => {
   let response: WorkerResponse
   try {
+    languageContext ||= new LanguageContext(
+      request.vue ? [createVueLanguage(request.vue)] : [],
+    )
     const options: TscOptions = {
       ...request.options,
-      // Structured clone preserves the data but not the class prototype.
-      languageContext: new LanguageContext(
-        request.options.languageContext.languages,
-      ),
+      languageContext,
     }
     response = { id: request.id, result: tscEmit(options) }
   } catch (error) {

--- a/src/tsgo.ts
+++ b/src/tsgo.ts
@@ -1,0 +1,96 @@
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { styleText } from 'node:util'
+import { tryRequire, tryResolve } from './require.ts'
+import type { Logger } from './options.ts'
+
+export interface TsgoPackageInfo {
+  moduleUrl: string
+  api?: TsgoApiModule
+  hasClassicApi: boolean
+}
+
+export type TsgoApiModule = typeof import('typescript-next/unstable/async')
+
+export function getDefaultTsgoModuleUrl(): string | undefined {
+  try {
+    // Tests replace the CommonJS resolver to exercise different installations.
+    if (import.meta.TEST) {
+      const modulePath = tryResolve('typescript')
+      return modulePath && pathToFileURL(modulePath).href
+    }
+    return import.meta.resolve('typescript')
+  } catch {}
+}
+
+function getModulePath(moduleUrl: string): string {
+  return moduleUrl.startsWith('file:') ? fileURLToPath(moduleUrl) : moduleUrl
+}
+
+export function getTsgoPackageInfo(
+  moduleUrl: string | undefined,
+): TsgoPackageInfo | undefined {
+  if (!moduleUrl) return
+
+  let modulePath: string
+  try {
+    modulePath = getModulePath(moduleUrl)
+  } catch {
+    return { moduleUrl, hasClassicApi: false }
+  }
+
+  const rootModule = tryRequire<TsgoApiModule & typeof import('typescript')>(
+    modulePath,
+  )
+  const apiPath = tryResolve('typescript/unstable/async', {
+    paths: [path.dirname(modulePath)],
+  })
+  const api = rootModule?.Program?.prototype.getDeclarationEmit
+    ? rootModule
+    : apiPath
+      ? tryRequire<TsgoApiModule>(apiPath)
+      : undefined
+  return {
+    moduleUrl,
+    api,
+    hasClassicApi: typeof rootModule?.createProgram === 'function',
+  }
+}
+
+export function getDefaultTsgoGenerator(): 'tsgo' | undefined {
+  const pkg = getTsgoPackageInfo(getDefaultTsgoModuleUrl())
+  if (
+    pkg?.api?.Program?.prototype.getDeclarationEmit ||
+    (pkg && !pkg.hasClassicApi)
+  ) {
+    return 'tsgo'
+  }
+}
+
+function logPackage(logger: Logger, pkg: TsgoPackageInfo): void {
+  logger.info(
+    `Emit types with TypeScript Go from ${styleText('underline', pkg.moduleUrl)}`,
+  )
+}
+
+export function resolveTsgoApiPackage(
+  logger?: Logger,
+  moduleUrl: string | undefined = getDefaultTsgoModuleUrl(),
+): TsgoPackageInfo {
+  const pkg = getTsgoPackageInfo(moduleUrl)
+  if (!pkg?.api?.Program?.prototype.getDeclarationEmit) {
+    throw new Error(
+      `The TypeScript module${moduleUrl ? ` at ${moduleUrl}` : ''} does not provide the tsgo \`getDeclarationEmit\` API. Please install \`typescript@next\` or set \`tsgo.moduleUrl\` to a compatible module, for example \`import.meta.resolve('typescript-next')\`.`,
+    )
+  }
+
+  if (logger) logPackage(logger, pkg)
+  return pkg
+}
+
+export function loadTsgoApi(
+  moduleUrl: string | undefined = getDefaultTsgoModuleUrl(),
+): TsgoApiModule {
+  const pkg = resolveTsgoApiPackage(undefined, moduleUrl)
+  return pkg.api!
+}

--- a/src/tsgo.ts
+++ b/src/tsgo.ts
@@ -33,15 +33,10 @@ export function getTsgoPackageInfo(
     return
   }
 
-  const ts = tryRequire<typeof TsgoApiModule>(modulePath)
   const apiPath = tryResolve('typescript/unstable/async', {
     paths: [path.dirname(modulePath)],
   })
-  const api = ts?.Program?.prototype.getDeclarationEmit
-    ? ts
-    : apiPath
-      ? tryRequire<typeof TsgoApiModule>(apiPath)
-      : undefined
+  const api = apiPath ? tryRequire<typeof TsgoApiModule>(apiPath) : undefined
   return {
     api,
     hasTsgoApi: !!api?.Program?.prototype.getDeclarationEmit,

--- a/src/tsgo.ts
+++ b/src/tsgo.ts
@@ -5,7 +5,6 @@ import { tryRequire, tryResolve } from './require.ts'
 import type { Logger } from './options.ts'
 
 export interface TsgoPackageInfo {
-  moduleUrl: string
   api?: TsgoApiModule
   hasClassicApi: boolean
 }
@@ -23,60 +22,37 @@ export function getDefaultTsgoModuleUrl(): string | undefined {
   } catch {}
 }
 
-function getModulePath(moduleUrl: string): string {
-  return moduleUrl.startsWith('file:') ? fileURLToPath(moduleUrl) : moduleUrl
-}
-
 export function getTsgoPackageInfo(
   moduleUrl: string | undefined,
 ): TsgoPackageInfo | undefined {
   if (!moduleUrl) return
 
-  let modulePath: string
+  let modulePath = moduleUrl
   try {
-    modulePath = getModulePath(moduleUrl)
+    if (moduleUrl.startsWith('file:')) modulePath = fileURLToPath(moduleUrl)
   } catch {
-    return { moduleUrl, hasClassicApi: false }
+    return
   }
 
-  const rootModule = tryRequire<TsgoApiModule & typeof import('typescript')>(
-    modulePath,
-  )
+  const ts = tryRequire<TsgoApiModule & typeof import('typescript')>(modulePath)
   const apiPath = tryResolve('typescript/unstable/async', {
     paths: [path.dirname(modulePath)],
   })
-  const api = rootModule?.Program?.prototype.getDeclarationEmit
-    ? rootModule
+  const api = ts?.Program?.prototype.getDeclarationEmit
+    ? ts
     : apiPath
       ? tryRequire<TsgoApiModule>(apiPath)
       : undefined
   return {
-    moduleUrl,
     api,
-    hasClassicApi: typeof rootModule?.createProgram === 'function',
+    hasClassicApi: typeof ts?.createProgram === 'function',
   }
 }
 
-export function getDefaultTsgoGenerator(): 'tsgo' | undefined {
-  const pkg = getTsgoPackageInfo(getDefaultTsgoModuleUrl())
-  if (
-    pkg?.api?.Program?.prototype.getDeclarationEmit ||
-    (pkg && !pkg.hasClassicApi)
-  ) {
-    return 'tsgo'
-  }
-}
-
-function logPackage(logger: Logger, pkg: TsgoPackageInfo): void {
-  logger.info(
-    `Emit types with TypeScript Go from ${styleText('underline', pkg.moduleUrl)}`,
-  )
-}
-
-export function resolveTsgoApiPackage(
-  logger?: Logger,
+export function loadTsgoApi(
   moduleUrl: string | undefined = getDefaultTsgoModuleUrl(),
-): TsgoPackageInfo {
+  logger?: Logger,
+): TsgoApiModule {
   const pkg = getTsgoPackageInfo(moduleUrl)
   if (!pkg?.api?.Program?.prototype.getDeclarationEmit) {
     throw new Error(
@@ -84,13 +60,10 @@ export function resolveTsgoApiPackage(
     )
   }
 
-  if (logger) logPackage(logger, pkg)
-  return pkg
-}
-
-export function loadTsgoApi(
-  moduleUrl: string | undefined = getDefaultTsgoModuleUrl(),
-): TsgoApiModule {
-  const pkg = resolveTsgoApiPackage(undefined, moduleUrl)
-  return pkg.api!
+  if (logger && moduleUrl) {
+    logger.info(
+      `Emit types with TypeScript Go from ${styleText('underline', moduleUrl)}`,
+    )
+  }
+  return pkg.api
 }

--- a/src/tsgo.ts
+++ b/src/tsgo.ts
@@ -3,13 +3,12 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { styleText } from 'node:util'
 import { tryRequire, tryResolve } from './require.ts'
 import type { Logger } from './options.ts'
+import type * as TsgoApiModule from 'typescript-next/unstable/async'
 
 export interface TsgoPackageInfo {
-  api?: TsgoApiModule
-  hasClassicApi: boolean
+  api?: typeof TsgoApiModule
+  hasTsgoApi: boolean
 }
-
-export type TsgoApiModule = typeof import('typescript-next/unstable/async')
 
 export function getDefaultTsgoModuleUrl(): string | undefined {
   try {
@@ -34,27 +33,27 @@ export function getTsgoPackageInfo(
     return
   }
 
-  const ts = tryRequire<TsgoApiModule & typeof import('typescript')>(modulePath)
+  const ts = tryRequire<typeof TsgoApiModule>(modulePath)
   const apiPath = tryResolve('typescript/unstable/async', {
     paths: [path.dirname(modulePath)],
   })
   const api = ts?.Program?.prototype.getDeclarationEmit
     ? ts
     : apiPath
-      ? tryRequire<TsgoApiModule>(apiPath)
+      ? tryRequire<typeof TsgoApiModule>(apiPath)
       : undefined
   return {
     api,
-    hasClassicApi: typeof ts?.createProgram === 'function',
+    hasTsgoApi: !!api?.Program?.prototype.getDeclarationEmit,
   }
 }
 
 export function loadTsgoApi(
   moduleUrl: string | undefined = getDefaultTsgoModuleUrl(),
   logger?: Logger,
-): TsgoApiModule {
+): typeof TsgoApiModule {
   const pkg = getTsgoPackageInfo(moduleUrl)
-  if (!pkg?.api?.Program?.prototype.getDeclarationEmit) {
+  if (!pkg?.hasTsgoApi) {
     throw new Error(
       `The TypeScript module${moduleUrl ? ` at ${moduleUrl}` : ''} does not provide the tsgo \`getDeclarationEmit\` API. Please install \`typescript@next\` or set \`tsgo.moduleUrl\` to a compatible module, for example \`import.meta.resolve('typescript-next')\`.`,
     )
@@ -65,5 +64,5 @@ export function loadTsgoApi(
       `Emit types with TypeScript Go from ${styleText('underline', moduleUrl)}`,
     )
   }
-  return pkg.api
+  return pkg.api!
 }

--- a/tests/__snapshots__/custom-language.test.ts.snap
+++ b/tests/__snapshots__/custom-language.test.ts.snap
@@ -103,6 +103,23 @@ declare const _default: typeof __VLS_export;
 export { _default as default };"
 `;
 
+exports[`volar > vue > vue-sfc w/ parallel ts-compiler 1`] = `
+"// main.d.ts
+//#region tests/fixtures/vue-sfc/App.vue.d.ts
+type __VLS_Props = {
+  foo: string;
+};
+declare global {
+  interface Window {
+    foo: string;
+  }
+}
+declare const __VLS_export: import("@vue/runtime-core").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("@vue/runtime-core").ComponentOptionsMixin, import("@vue/runtime-core").ComponentOptionsMixin, {}, string, import("@vue/runtime-core").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("@vue/runtime-core").ComponentProvideOptions, false, {}, any>;
+declare const _default: typeof __VLS_export;
+//#endregion
+export { _default as App };"
+`;
+
 exports[`volar > vue > vue-sfc w/ ts-compiler 1`] = `
 "// main.d.ts
 //#region tests/fixtures/vue-sfc/App.vue.d.ts

--- a/tests/__snapshots__/custom-language.test.ts.snap
+++ b/tests/__snapshots__/custom-language.test.ts.snap
@@ -35,6 +35,25 @@ export { foo };
 "
 `;
 
+exports[`volar > custom without volar (tsgo vfs) 1`] = `
+"// main.d.ts
+//#region tests/fixtures/custom-language/foo.custom.d.ts
+export declare const foo: string;
+//#endregion
+//# sourceMappingURL=main.d.ts.map
+// main.d.ts.map
+{"version":3,"file":"main.d.ts","names":[],"sources":["../tests/fixtures/custom-language/foo.custom"],"mappings":";qBACa"}
+// main.js
+//#region tests/fixtures/custom-language/foo.custom
+const foo = "bar";
+//#endregion
+export { foo };
+
+//# sourceMappingURL=main.js.map
+// main.js.map
+{"version":3,"file":"main.js","names":[],"sources":[],"mappings":""}"
+`;
+
 exports[`volar > ts-macro > ts-macro w/ ts-compiler 1`] = `
 "// main.d.ts
 //#region tests/fixtures/ts-macro/main.d.ts

--- a/tests/custom-language.test.ts
+++ b/tests/custom-language.test.ts
@@ -8,6 +8,7 @@ import type { CustomLanguage } from '../src/custom-language.ts'
 
 const { dirname } = import.meta
 const require = createRequire(import.meta.url)
+const tsgoModuleUrl = import.meta.resolve('typescript-next')
 
 const external = ['vue', /^@vue/]
 
@@ -150,6 +151,39 @@ describe('volar', () => {
       expect(snapshot).toMatchSnapshot()
     },
   )
+
+  test('custom without volar (tsgo vfs)', async () => {
+    const root = path.resolve(dirname, 'fixtures/custom-language')
+    const RE_CUSTOM = /\.custom$/
+    const { snapshot } = await rolldownBuild(path.resolve(root, 'main.ts'), [
+      {
+        name: 'convert-custom-to-ts',
+        transform: {
+          order: 'pre',
+          filter: { id: RE_CUSTOM },
+          handler: (code) => ({
+            code: code.replace('<script>', '').replace('</script>', ''),
+            moduleType: 'ts',
+          }),
+        },
+      },
+      dts({
+        generator: 'tsgo',
+        tsconfig: path.resolve(root, 'tsconfig.json'),
+        sourcemap: true,
+        tsgo: { moduleUrl: tsgoModuleUrl, vfs: true },
+        customLanguages: [
+          {
+            extensionPatterns: [RE_CUSTOM],
+            toTsFilename: (id) => id.replace(RE_CUSTOM, '.custom.ts'),
+          },
+        ],
+      }),
+    ])
+
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('declare const foo: string')
+  })
 })
 
 function createTsMacroLanguage(): CustomLanguage {

--- a/tests/custom-language.test.ts
+++ b/tests/custom-language.test.ts
@@ -42,7 +42,7 @@ describe('volar', () => {
             vue: {
               vueCompilerOptions: { fallthroughAttributes: false },
             },
-            parallel: true,
+            tsc: { parallel: true },
             compilerOptions: {
               isolatedDeclarations: false,
             },

--- a/tests/custom-language.test.ts
+++ b/tests/custom-language.test.ts
@@ -32,6 +32,27 @@ describe('volar', () => {
       expect(snapshot).toMatchSnapshot()
     })
 
+    test('vue-sfc w/ parallel ts-compiler', async () => {
+      const root = path.resolve(dirname, 'fixtures/vue-sfc')
+      const { snapshot } = await rolldownBuild(
+        path.resolve(root, 'main.ts'),
+        [
+          dts({
+            emitDtsOnly: true,
+            vue: {
+              vueCompilerOptions: { fallthroughAttributes: false },
+            },
+            parallel: true,
+            compilerOptions: {
+              isolatedDeclarations: false,
+            },
+          }),
+        ],
+        { external },
+      )
+      expect(snapshot).toMatchSnapshot()
+    })
+
     test('vue-sfc w/ ts-compiler w/ vueCompilerOptions in tsconfig', async () => {
       const root = path.resolve(dirname, 'fixtures/vue-sfc-fallthrough')
       const { snapshot } = await rolldownBuild(

--- a/tests/fixtures/custom-language/tsconfig.json
+++ b/tests/fixtures/custom-language/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["main.ts"]
+}

--- a/tests/fixtures/tsgo-vfs/a.ts
+++ b/tests/fixtures/tsgo-vfs/a.ts
@@ -1,0 +1,3 @@
+import { valueB } from './b.ts'
+
+export const pair = { valueB }

--- a/tests/fixtures/tsgo-vfs/b.ts
+++ b/tests/fixtures/tsgo-vfs/b.ts
@@ -1,0 +1,1 @@
+export const valueB: number = 1

--- a/tests/fixtures/tsgo-vfs/tsconfig.json
+++ b/tests/fixtures/tsgo-vfs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "declaration": true
+  },
+  "include": ["*.ts"]
+}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -128,7 +128,7 @@ interface Fixture {
   isolatedDecl?: boolean
   oxc?: Options['oxc']
   vue?: boolean
-  parallel?: boolean
+  tsc?: Options['tsc']
   customLanguages?: Options['customLanguages']
   tsgo?: Options['tsgo']
   generator?: Options['generator']
@@ -149,7 +149,8 @@ function formatTitle(fixture: Fixture): string {
   if (fixture.oxc !== undefined)
     parts.push(`oxc=${JSON.stringify(fixture.oxc)}`)
   if (fixture.vue) parts.push('vue')
-  if (fixture.parallel) parts.push('parallel')
+  if (fixture.tsc !== undefined)
+    parts.push(`tsc=${JSON.stringify(fixture.tsc)}`)
   if (fixture.customLanguages)
     parts.push(
       `langs=[${fixture.customLanguages
@@ -177,6 +178,23 @@ describe('resolve generator', () => {
     expect(resolveOptions({ generator, tsconfig: false }).generator).toBe(
       generator,
     )
+  })
+
+  test('resolves tsc.incremental from compiler options and allows overrides', () => {
+    mockInstalled([6, false])
+    expect(
+      resolveOptions({
+        tsconfig: false,
+        compilerOptions: { incremental: true },
+      }).tsc.incremental,
+    ).toBe(true)
+    expect(
+      resolveOptions({
+        tsconfig: false,
+        compilerOptions: { incremental: true },
+        tsc: { incremental: false },
+      }).tsc.incremental,
+    ).toBe(false)
   })
 
   const fixtures: Fixture[] = [
@@ -230,7 +248,7 @@ describe('resolve generator', () => {
     { installed: ['next', 'next'], isolatedDecl: true, expected: 'oxc' },
     //#endregion
 
-    //#region oxc / tsgo settings do not select the generator
+    //#region generator settings do not select the generator
     { oxc: {}, expected: 'tsc' },
     { oxc: { stripInternal: true }, expected: 'tsc' },
     { tsgo: {}, expected: 'tsc' },
@@ -240,6 +258,12 @@ describe('resolve generator', () => {
       installed: [6, 'next'],
       tsgo: { moduleUrl: CUSTOM_MODULE_URL },
       expected: 'tsc',
+    },
+    {
+      installed: ['next', false],
+      tsc: { parallel: true },
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
     },
     { oxc: {}, isolatedDecl: true, expected: 'oxc' },
     // Native compiler inference still applies with tsgo settings present.
@@ -267,6 +291,16 @@ describe('resolve generator', () => {
     },
     // explicit generator takes priority over inference
     { generator: 'tsc', isolatedDecl: true, expected: 'tsc' },
+    {
+      generator: 'tsc',
+      tsc: {
+        build: true,
+        incremental: true,
+        eager: true,
+        newContext: true,
+      },
+      expected: 'tsc',
+    },
     { installed: [false, false], generator: 'oxc', expected: 'oxc' },
     { generator: 'oxc', expected: 'oxc' },
     { installed: [7, 'next'], generator: 'oxc', expected: 'oxc' },
@@ -383,7 +417,7 @@ describe('resolve generator', () => {
       isThrow: true,
     },
     { vue: true, generator: 'tsc', expected: 'tsc' },
-    { vue: true, parallel: true, expected: 'tsc' },
+    { vue: true, tsc: { parallel: true }, expected: 'tsc' },
     { vue: true, isolatedDecl: true, expected: 'tsc' },
     // tsgo settings are ignored when tsc is selected
     { installed: [6, 'next'], vue: true, tsgo: {}, expected: 'tsc' },
@@ -418,7 +452,7 @@ describe('resolve generator', () => {
     },
     {
       customLanguages: [volarLanguage],
-      parallel: true,
+      tsc: { parallel: true },
       expected: 'does not support `customLanguages`',
       isThrow: true,
     },
@@ -464,7 +498,7 @@ describe('resolve generator', () => {
     {
       customLanguages: [plainLanguage],
       generator: 'tsc',
-      parallel: true,
+      tsc: { parallel: true },
       expected: 'does not support `customLanguages`',
       isThrow: true,
     },
@@ -499,7 +533,7 @@ describe('resolve generator', () => {
         isolatedDecl,
         oxc,
         vue,
-        parallel,
+        tsc,
         customLanguages,
         tsgo,
         generator,
@@ -518,7 +552,7 @@ describe('resolve generator', () => {
         },
         oxc,
         vue,
-        parallel,
+        tsc: tsc && { ...tsc },
         // resolveOptions may push into the array (e.g. vue), so avoid
         // sharing the same array between fixtures
         customLanguages: customLanguages && [...customLanguages],
@@ -539,6 +573,13 @@ describe('resolve generator', () => {
         tsgo?.moduleUrl ?? (installed[0] ? TYPESCRIPT_MODULE_URL : undefined),
       )
       expect(resolved.tsgo.vfs).toBe(tsgo?.vfs ?? false)
+      expect(resolved.tsc).toStrictEqual({
+        build: tsc?.build ?? false,
+        incremental: tsc?.incremental ?? false,
+        parallel: tsc?.parallel ?? false,
+        eager: tsc?.eager ?? false,
+        newContext: tsc?.newContext ?? false,
+      })
       if (selectedPackage) {
         expect(logger.info.mock.calls.flat().join(' ')).toContain(
           selectedPackage,

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { resolveOptions, type Options } from '../src/options.ts'
 import { mockRequire } from '../src/require.ts'
 import type { CustomLanguage } from '../src/custom-language.ts'
+import type { Generator } from '../src/index.ts'
 
 const realRequire = createRequire(import.meta.url)
 
@@ -165,6 +166,17 @@ function formatTitle(fixture: Fixture): string {
 }
 
 describe('resolve generator', () => {
+  test('preserves a custom generator without compiler inference', () => {
+    mockInstalled([false, false])
+    const generator: Generator = {
+      emit: () => ({ code: '' }),
+    }
+
+    expect(resolveOptions({ generator, tsconfig: false }).generator).toBe(
+      generator,
+    )
+  })
+
   const fixtures: Fixture[] = [
     //#region inference (no custom language)
     { expected: 'tsc' }, // TS 6 installed by default

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -128,6 +128,7 @@ interface Fixture {
   isolatedDecl?: boolean
   oxc?: Options['oxc']
   vue?: boolean
+  parallel?: boolean
   customLanguages?: Options['customLanguages']
   tsgo?: Options['tsgo']
   generator?: Options['generator']
@@ -148,6 +149,7 @@ function formatTitle(fixture: Fixture): string {
   if (fixture.oxc !== undefined)
     parts.push(`oxc=${JSON.stringify(fixture.oxc)}`)
   if (fixture.vue) parts.push('vue')
+  if (fixture.parallel) parts.push('parallel')
   if (fixture.customLanguages)
     parts.push(
       `langs=[${fixture.customLanguages
@@ -381,6 +383,7 @@ describe('resolve generator', () => {
       isThrow: true,
     },
     { vue: true, generator: 'tsc', expected: 'tsc' },
+    { vue: true, parallel: true, expected: 'tsc' },
     { vue: true, isolatedDecl: true, expected: 'tsc' },
     // tsgo settings are ignored when tsc is selected
     { installed: [6, 'next'], vue: true, tsgo: {}, expected: 'tsc' },
@@ -411,6 +414,12 @@ describe('resolve generator', () => {
       customLanguages: [volarLanguage],
       generator: 'tsgo',
       expected: 'require the `tsc` generator',
+      isThrow: true,
+    },
+    {
+      customLanguages: [volarLanguage],
+      parallel: true,
+      expected: 'does not support `customLanguages`',
       isThrow: true,
     },
     { customLanguages: [volarLanguage], isolatedDecl: true, expected: 'tsc' },
@@ -452,6 +461,13 @@ describe('resolve generator', () => {
       expected: 'tsgo',
     },
     { customLanguages: [plainLanguage], generator: 'tsc', expected: 'tsc' },
+    {
+      customLanguages: [plainLanguage],
+      generator: 'tsc',
+      parallel: true,
+      expected: 'does not support `customLanguages`',
+      isThrow: true,
+    },
     { customLanguages: [plainLanguage], generator: 'oxc', expected: 'oxc' },
     {
       customLanguages: [plainLanguage],
@@ -483,6 +499,7 @@ describe('resolve generator', () => {
         isolatedDecl,
         oxc,
         vue,
+        parallel,
         customLanguages,
         tsgo,
         generator,
@@ -501,6 +518,7 @@ describe('resolve generator', () => {
         },
         oxc,
         vue,
+        parallel,
         // resolveOptions may push into the array (e.g. vue), so avoid
         // sharing the same array between fixtures
         customLanguages: customLanguages && [...customLanguages],

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -184,14 +184,14 @@ describe('resolve generator', () => {
     {
       installed: [7, false],
       tsconfig: TSCONFIG,
-      expected: 'does not provide the tsgo `getDeclarationEmit` API',
+      expected: 'classic TypeScript API required by tsc',
       isThrow: true,
     },
     {
       // A custom module is only used when configured through moduleUrl.
       installed: [7, 'next'],
       tsconfig: TSCONFIG,
-      expected: 'does not provide the tsgo `getDeclarationEmit` API',
+      expected: 'classic TypeScript API required by tsc',
       isThrow: true,
     },
     { installed: ['next', false], tsconfig: TSCONFIG, expected: 'tsgo' },
@@ -199,7 +199,7 @@ describe('resolve generator', () => {
     { installed: ['api', false], tsconfig: TSCONFIG, expected: 'tsgo' },
     {
       installed: [7, false],
-      expected: 'The `tsgo` generator requires a tsconfig file',
+      expected: 'classic TypeScript API required by tsc',
       isThrow: true,
     },
     {
@@ -422,7 +422,7 @@ describe('resolve generator', () => {
       installed: [7, false],
       customLanguages: [plainLanguage],
       tsconfig: TSCONFIG,
-      expected: 'requires `tsgo.vfs: true`',
+      expected: 'classic TypeScript API required by tsc',
       isThrow: true,
     },
     {

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { resolveOptions, type Options } from '../src/options.ts'
@@ -7,10 +8,27 @@ import type { CustomLanguage } from '../src/custom-language.ts'
 
 const realRequire = createRequire(import.meta.url)
 
-const TYPESCRIPT_MODULE_PATH = '/mock/typescript/lib/typescript.js'
+const MOCK_ROOT = path.join(path.parse(import.meta.dirname).root, 'mock')
+const TYPESCRIPT_MODULE_PATH = path.join(
+  MOCK_ROOT,
+  'typescript/lib/typescript.js',
+)
 const TYPESCRIPT_MODULE_URL = pathToFileURL(TYPESCRIPT_MODULE_PATH).href
-const CUSTOM_MODULE_PATH = '/mock/xxx/lib/index.js'
+const TYPESCRIPT_PACKAGE_JSON_PATH = path.join(
+  MOCK_ROOT,
+  'typescript/package.json',
+)
+const TYPESCRIPT_API_PATH = path.join(
+  MOCK_ROOT,
+  'typescript/dist/api/async/api.js',
+)
+const CUSTOM_MODULE_PATH = path.join(MOCK_ROOT, 'xxx/lib/index.js')
 const CUSTOM_MODULE_URL = pathToFileURL(CUSTOM_MODULE_PATH).href
+const CUSTOM_API_PATH = path.join(MOCK_ROOT, 'xxx/dist/api/async/api.js')
+
+function normalizePath(fileName: string): string {
+  return fileName.replaceAll('\\', '/')
+}
 
 type PackageVersion = 6 | 7 | 'api' | 'next' | false
 type Installed = [ts: PackageVersion, custom: PackageVersion]
@@ -24,27 +42,30 @@ function getVersion(version: Exclude<PackageVersion, false>): string {
 
 function mockInstalled([ts, custom]: Installed) {
   const fake = ((rawId: string) => {
-    const id = rawId.replaceAll('\\', '/')
+    const id = normalizePath(rawId)
     switch (id) {
       case 'typescript': {
         if (!ts) throw new Error(`Cannot find module 'typescript'`)
         return ts === 6 || ts === 'api' ? { createProgram() {} } : {}
       }
-      case TYPESCRIPT_MODULE_PATH:
+      case normalizePath(TYPESCRIPT_MODULE_PATH):
         if (!ts) throw new Error(`Cannot find module '${id}'`)
         return ts === 6 || ts === 'api' ? { createProgram() {} } : {}
-      case CUSTOM_MODULE_PATH:
+      case normalizePath(CUSTOM_MODULE_PATH):
         if (!custom) throw new Error(`Cannot find module '${id}'`)
         return custom === 6 || custom === 'api' ? { createProgram() {} } : {}
       case 'typescript/package.json':
-      case '/mock/typescript/package.json': {
+      case normalizePath(TYPESCRIPT_PACKAGE_JSON_PATH): {
         if (!ts) throw new Error(`Cannot find module '${id}'`)
         return { version: getVersion(ts) }
       }
     }
-    const apiSource = ['typescript', 'xxx'].find(
-      (source) => id === `/mock/${source}/dist/api/async/api.js`,
-    )
+    const apiSource =
+      id === normalizePath(TYPESCRIPT_API_PATH)
+        ? 'typescript'
+        : id === normalizePath(CUSTOM_API_PATH)
+          ? 'xxx'
+          : undefined
     if (apiSource) {
       const installed = apiSource === 'typescript' ? ts : custom
       return {
@@ -67,17 +88,21 @@ function mockInstalled([ts, custom]: Installed) {
     }
     if (id === 'typescript/package.json') {
       if (!ts) throw new Error(`Cannot find module '${id}'`)
-      return '/mock/typescript/package.json'
+      return TYPESCRIPT_PACKAGE_JSON_PATH
     }
     if (id === 'typescript/unstable/async') {
-      const isCustom = options?.paths?.some((value) =>
-        value.replaceAll('\\', '/').startsWith('/mock/xxx/'),
-      )
+      const customRoot = normalizePath(path.join(MOCK_ROOT, 'xxx'))
+      const isCustom = options?.paths?.some((value) => {
+        const normalized = normalizePath(value)
+        return (
+          normalized === customRoot || normalized.startsWith(`${customRoot}/`)
+        )
+      })
       const installed = isCustom ? custom : ts
       if (!installed || installed === 6) {
         throw new Error(`Cannot find module '${id}'`)
       }
-      return `/mock/${isCustom ? 'xxx' : 'typescript'}/dist/api/async/api.js`
+      return isCustom ? CUSTOM_API_PATH : TYPESCRIPT_API_PATH
     }
     return realRequire.resolve(id, options)
   }) as NodeJS.RequireResolve

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { resolveOptions, type Options } from '../src/options.ts'
 import { mockRequire } from '../src/require.ts'
@@ -6,43 +7,77 @@ import type { CustomLanguage } from '../src/custom-language.ts'
 
 const realRequire = createRequire(import.meta.url)
 
-const MOCK_TSGO_BIN = '/mock/bin/tsgo'
-const TSGO_PKGS = ['typescript', '@typescript/native-preview']
+const TYPESCRIPT_MODULE_PATH = '/mock/typescript/lib/typescript.js'
+const TYPESCRIPT_MODULE_URL = pathToFileURL(TYPESCRIPT_MODULE_PATH).href
+const CUSTOM_MODULE_PATH = '/mock/xxx/lib/index.js'
+const CUSTOM_MODULE_URL = pathToFileURL(CUSTOM_MODULE_PATH).href
 
-type Installed = [ts: 6 | 7 | false, tsgo: boolean]
+type PackageVersion = 6 | 7 | 'api' | 'next' | false
+type Installed = [ts: PackageVersion, custom: PackageVersion]
 
-function mockInstalled([ts, tsgo]: Installed) {
+function getVersion(version: Exclude<PackageVersion, false>): string {
+  if (version === 6) return '6.0.0'
+  if (version === 7) return '7.0.2'
+  if (version === 'api') return '6.0.0'
+  return '7.1.0-dev.20260830.1'
+}
+
+function mockInstalled([ts, custom]: Installed) {
   const fake = ((rawId: string) => {
-    // On Windows, `path.join` in `resolveTsgoPath` turns the fake `/mock/...`
-    // paths into backslash form; normalize for comparison only.
     const id = rawId.replaceAll('\\', '/')
     switch (id) {
       case 'typescript': {
         if (!ts) throw new Error(`Cannot find module 'typescript'`)
-        return {}
+        return ts === 6 || ts === 'api' ? { createProgram() {} } : {}
       }
+      case TYPESCRIPT_MODULE_PATH:
+        if (!ts) throw new Error(`Cannot find module '${id}'`)
+        return ts === 6 || ts === 'api' ? { createProgram() {} } : {}
+      case CUSTOM_MODULE_PATH:
+        if (!custom) throw new Error(`Cannot find module '${id}'`)
+        return custom === 6 || custom === 'api' ? { createProgram() {} } : {}
       case 'typescript/package.json':
       case '/mock/typescript/package.json': {
         if (!ts) throw new Error(`Cannot find module '${id}'`)
-        return { version: ts === 6 ? '6.0.0' : '7.0.0' }
-      }
-      case '@typescript/native-preview/package.json':
-      case '/mock/@typescript/native-preview/package.json': {
-        if (!tsgo) throw new Error(`Cannot find module '${id}'`)
-        return { version: '7.0.0-preview' }
+        return { version: getVersion(ts) }
       }
     }
-    if (TSGO_PKGS.some((pkg) => id === `/mock/${pkg}/lib/getExePath.js`)) {
-      return { default: () => MOCK_TSGO_BIN }
+    const apiSource = ['typescript', 'xxx'].find(
+      (source) => id === `/mock/${source}/dist/api/async/api.js`,
+    )
+    if (apiSource) {
+      const installed = apiSource === 'typescript' ? ts : custom
+      return {
+        API: class {},
+        Program:
+          installed === 'api' || installed === 'next'
+            ? class {
+                getDeclarationEmit() {}
+              }
+            : class {},
+      }
     }
     // vue / Volar related modules are loaded for real
     return realRequire(rawId)
   }) as NodeJS.Require
   fake.resolve = ((id: string, options?: { paths?: string[] }) => {
-    if (TSGO_PKGS.some((pkg) => id === `${pkg}/package.json`)) {
-      const installed = id.startsWith('typescript') ? ts : tsgo
-      if (!installed) throw new Error(`Cannot find module '${id}'`)
-      return `/mock/${id}`
+    if (id === 'typescript') {
+      if (!ts) throw new Error(`Cannot find module '${id}'`)
+      return TYPESCRIPT_MODULE_PATH
+    }
+    if (id === 'typescript/package.json') {
+      if (!ts) throw new Error(`Cannot find module '${id}'`)
+      return '/mock/typescript/package.json'
+    }
+    if (id === 'typescript/unstable/async') {
+      const isCustom = options?.paths?.some((value) =>
+        value.replaceAll('\\', '/').startsWith('/mock/xxx/'),
+      )
+      const installed = isCustom ? custom : ts
+      if (!installed || installed === 6) {
+        throw new Error(`Cannot find module '${id}'`)
+      }
+      return `/mock/${isCustom ? 'xxx' : 'typescript'}/dist/api/async/api.js`
     }
     return realRequire.resolve(id, options)
   }) as NodeJS.RequireResolve
@@ -72,12 +107,13 @@ interface Fixture {
   generator?: Options['generator']
   tsconfig?: string
   expected: string
+  selectedPackage?: string
   isThrow?: boolean
 }
 
 function formatTitle(fixture: Fixture): string {
-  const [ts, preview] = fixture.installed ?? [6, false]
-  const env = [ts ? `ts${ts}` : 'no-ts', preview && 'preview']
+  const [ts, custom] = fixture.installed ?? [6, false]
+  const env = [ts ? `ts${ts}` : 'no-ts', custom && 'custom']
     .filter(Boolean)
     .join('+')
 
@@ -108,10 +144,10 @@ describe('resolve generator', () => {
     //#region inference (no custom language)
     { expected: 'tsc' }, // TS 6 installed by default
     { installed: [6, false], expected: 'tsc' },
-    // native-preview does not participate in inference
-    { installed: [6, true], expected: 'tsc' },
+    // A custom module does not participate in inference.
+    { installed: [6, 'next'], expected: 'tsc' },
     {
-      installed: [false, true],
+      installed: [false, 'next'],
       expected: 'TypeScript is not installed',
       isThrow: true,
     },
@@ -120,10 +156,29 @@ describe('resolve generator', () => {
       expected: 'TypeScript is not installed',
       isThrow: true,
     },
-    { installed: [7, false], tsconfig: TSCONFIG, expected: 'tsgo' },
-    { installed: [7, true], tsconfig: TSCONFIG, expected: 'tsgo' },
     {
       installed: [7, false],
+      tsconfig: TSCONFIG,
+      expected: 'does not provide the tsgo `getDeclarationEmit` API',
+      isThrow: true,
+    },
+    {
+      // A custom module is only used when configured through moduleUrl.
+      installed: [7, 'next'],
+      tsconfig: TSCONFIG,
+      expected: 'does not provide the tsgo `getDeclarationEmit` API',
+      isThrow: true,
+    },
+    { installed: ['next', false], tsconfig: TSCONFIG, expected: 'tsgo' },
+    // API capability, rather than the package version, selects tsgo.
+    { installed: ['api', false], tsconfig: TSCONFIG, expected: 'tsgo' },
+    {
+      installed: [7, false],
+      expected: 'The `tsgo` generator requires a tsconfig file',
+      isThrow: true,
+    },
+    {
+      installed: ['next', false],
       expected: 'The `tsgo` generator requires a tsconfig file',
       isThrow: true,
     },
@@ -132,8 +187,8 @@ describe('resolve generator', () => {
     //#region isolatedDeclarations inference
     { installed: [false, false], isolatedDecl: true, expected: 'oxc' },
     { isolatedDecl: true, expected: 'oxc' },
-    // isolatedDeclarations takes priority over TS 7.0 tsgo inference
-    { installed: [7, true], isolatedDecl: true, expected: 'oxc' },
+    // isolatedDeclarations takes priority over native compiler inference
+    { installed: ['next', 'next'], isolatedDecl: true, expected: 'oxc' },
     //#endregion
 
     //#region oxc / tsgo settings do not select the generator
@@ -141,9 +196,20 @@ describe('resolve generator', () => {
     { oxc: { stripInternal: true }, expected: 'tsc' },
     { tsgo: {}, expected: 'tsc' },
     { tsgo: { path: '/bin/tsgo' }, expected: 'tsc' },
+    { tsgo: { vfs: true }, expected: 'tsc' },
+    {
+      installed: [6, 'next'],
+      tsgo: { moduleUrl: CUSTOM_MODULE_URL },
+      expected: 'tsc',
+    },
     { oxc: {}, isolatedDecl: true, expected: 'oxc' },
-    // TS 7.0 inference still applies with tsgo settings present
-    { installed: [7, false], tsgo: {}, tsconfig: TSCONFIG, expected: 'tsgo' },
+    // Native compiler inference still applies with tsgo settings present.
+    {
+      installed: ['next', false],
+      tsgo: { path: '/bin/tsgo' },
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
+    },
     //#endregion
 
     //#region explicit generator
@@ -157,57 +223,86 @@ describe('resolve generator', () => {
     {
       installed: [7, false],
       generator: 'tsc',
-      expected: 'TypeScript 7.0 is not supported when using tsc',
+      expected: 'does not provide the classic TypeScript API required by tsc',
       isThrow: true,
     },
     // explicit generator takes priority over inference
     { generator: 'tsc', isolatedDecl: true, expected: 'tsc' },
     { installed: [false, false], generator: 'oxc', expected: 'oxc' },
     { generator: 'oxc', expected: 'oxc' },
-    { installed: [7, true], generator: 'oxc', expected: 'oxc' },
+    { installed: [7, 'next'], generator: 'oxc', expected: 'oxc' },
     { generator: 'oxc', oxc: { stripInternal: true }, expected: 'oxc' },
+    {
+      installed: ['next', false],
+      generator: 'tsgo',
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
+      selectedPackage: TYPESCRIPT_MODULE_URL,
+    },
+    {
+      installed: ['next', 'next'],
+      generator: 'tsgo',
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
+      selectedPackage: TYPESCRIPT_MODULE_URL,
+    },
+    {
+      installed: [7, 'next'],
+      generator: 'tsgo',
+      tsgo: { moduleUrl: CUSTOM_MODULE_URL },
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
+      selectedPackage: CUSTOM_MODULE_URL,
+    },
+    {
+      installed: [6, 'next'],
+      generator: 'tsgo',
+      tsgo: { moduleUrl: CUSTOM_MODULE_URL },
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
+      selectedPackage: CUSTOM_MODULE_URL,
+    },
+    {
+      installed: [6, 7],
+      generator: 'tsgo',
+      tsgo: { moduleUrl: CUSTOM_MODULE_URL },
+      tsconfig: TSCONFIG,
+      expected: CUSTOM_MODULE_URL,
+      isThrow: true,
+    },
     {
       installed: [7, false],
       generator: 'tsgo',
       tsconfig: TSCONFIG,
-      expected: 'tsgo',
-    },
-    {
-      installed: [6, true],
-      generator: 'tsgo',
-      tsconfig: TSCONFIG,
-      expected: 'tsgo',
-    },
-    {
-      installed: [6, true],
-      generator: 'tsgo',
-      isolatedDecl: true,
-      tsconfig: TSCONFIG,
-      expected: 'tsgo',
-    },
-    // tsgo binary is resolved at options-resolution time
-    {
-      generator: 'tsgo',
-      tsconfig: TSCONFIG,
-      expected: 'TypeScript Go is not installed',
+      expected: 'install `typescript@next`',
       isThrow: true,
     },
     {
       installed: [false, false],
       generator: 'tsgo',
       tsconfig: TSCONFIG,
-      expected: 'TypeScript Go is not installed',
+      expected: 'The TypeScript module does not provide',
       isThrow: true,
     },
-    // a custom tsgo path skips binary resolution
+    // A custom API server path still requires a package that provides the API.
     {
-      installed: [false, false],
+      installed: [6, 'next'],
       generator: 'tsgo',
-      tsgo: { path: '/bin/tsgo' },
+      tsgo: {
+        moduleUrl: CUSTOM_MODULE_URL,
+        path: '/bin/custom-tsserver',
+      },
       tsconfig: TSCONFIG,
       expected: 'tsgo',
     },
-    // the tsconfig requirement is checked before binary resolution
+    {
+      installed: [false, false],
+      generator: 'tsgo',
+      tsgo: { path: '/bin/custom-tsserver' },
+      tsconfig: TSCONFIG,
+      expected: 'The TypeScript module does not provide',
+      isThrow: true,
+    },
     {
       generator: 'tsgo',
       expected: 'The `tsgo` generator requires a tsconfig file',
@@ -226,7 +321,7 @@ describe('resolve generator', () => {
     {
       installed: [7, false],
       vue: true,
-      expected: 'TypeScript 7.0 is not supported when using Vue',
+      expected: 'does not provide the classic TypeScript API required by Vue',
       isThrow: true,
     },
     {
@@ -241,10 +336,17 @@ describe('resolve generator', () => {
       expected: 'require the `tsc` generator',
       isThrow: true,
     },
+    {
+      installed: ['next', false],
+      vue: true,
+      generator: 'tsgo',
+      expected: 'require the `tsc` generator',
+      isThrow: true,
+    },
     { vue: true, generator: 'tsc', expected: 'tsc' },
     { vue: true, isolatedDecl: true, expected: 'tsc' },
     // tsgo settings are ignored when tsc is selected
-    { installed: [6, true], vue: true, tsgo: {}, expected: 'tsc' },
+    { installed: [6, 'next'], vue: true, tsgo: {}, expected: 'tsc' },
     //#endregion
 
     //#region Volar-based custom language (requires tsc)
@@ -258,7 +360,8 @@ describe('resolve generator', () => {
     {
       installed: [7, false],
       customLanguages: [volarLanguage],
-      expected: 'TypeScript 7.0 is not supported when using custom languages',
+      expected:
+        'does not provide the classic TypeScript API required by custom languages',
       isThrow: true,
     },
     {
@@ -281,7 +384,7 @@ describe('resolve generator', () => {
     },
     //#endregion
 
-    //#region non-Volar custom language (oxc allowed, tsgo not)
+    //#region non-Volar custom language
     { customLanguages: [plainLanguage], expected: 'tsc' },
     {
       installed: [false, false],
@@ -293,26 +396,41 @@ describe('resolve generator', () => {
     {
       installed: [7, false],
       customLanguages: [plainLanguage],
-      expected:
-        'TypeScript 7.0 is installed, but the `tsgo` generator does not support custom languages',
+      tsconfig: TSCONFIG,
+      expected: 'requires `tsgo.vfs: true`',
       isThrow: true,
+    },
+    {
+      installed: ['next', false],
+      customLanguages: [plainLanguage],
+      tsconfig: TSCONFIG,
+      expected: 'requires `tsgo.vfs: true`',
+      isThrow: true,
+    },
+    {
+      installed: ['next', false],
+      customLanguages: [plainLanguage],
+      tsgo: { vfs: true },
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
     },
     { customLanguages: [plainLanguage], generator: 'tsc', expected: 'tsc' },
     { customLanguages: [plainLanguage], generator: 'oxc', expected: 'oxc' },
     {
       customLanguages: [plainLanguage],
       generator: 'tsgo',
-      expected: 'The `tsgo` generator does not support custom languages',
+      expected: 'requires `tsgo.vfs: true`',
       isThrow: true,
     },
     {
+      installed: [6, 'next'],
       customLanguages: [plainLanguage],
       generator: 'tsgo',
-      isolatedDecl: true,
-      expected: 'The `tsgo` generator does not support custom languages',
-      isThrow: true,
+      tsgo: { moduleUrl: CUSTOM_MODULE_URL, vfs: true },
+      tsconfig: TSCONFIG,
+      expected: 'tsgo',
     },
-    // tsgo settings are silently ignored with custom languages
+    // tsgo settings do not select a generator.
     { customLanguages: [plainLanguage], tsgo: {}, expected: 'tsc' },
     //#endregion
   ]
@@ -333,6 +451,7 @@ describe('resolve generator', () => {
         generator,
         tsconfig,
         expected,
+        selectedPackage,
         isThrow,
       },
     ) => {
@@ -359,7 +478,16 @@ describe('resolve generator', () => {
       const resolved = resolveOptions(options)
       expect(resolved.generator).toBe(expected)
       if (expected === 'tsgo') {
-        expect(resolved.tsgo.path).toBe(tsgo?.path ?? MOCK_TSGO_BIN)
+        expect(resolved.tsgo.path).toBe(tsgo?.path)
+      }
+      expect(resolved.tsgo.moduleUrl).toBe(
+        tsgo?.moduleUrl ?? (installed[0] ? TYPESCRIPT_MODULE_URL : undefined),
+      )
+      expect(resolved.tsgo.vfs).toBe(tsgo?.vfs ?? false)
+      if (selectedPackage) {
+        expect(logger.info.mock.calls.flat().join(' ')).toContain(
+          selectedPackage,
+        )
       }
     },
   )

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,11 +1,13 @@
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { normalizePath, rolldownBuild } from '@sxzz/test-utils'
 import { describe, expect, test } from 'vitest'
-import { resolveTsgoPath } from '../src/generator/tsgo.ts'
 import { dts } from '../src/index.ts'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const tsgoModuleUrl = import.meta.resolve('typescript-next')
 
 test('basic', async () => {
   const { snapshot } = await rolldownBuild(
@@ -648,22 +650,64 @@ test('infer false branch', async () => {
 })
 
 test('tsgo with custom path', async () => {
-  const tsgoPath = resolveTsgoPath({
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-  })
+  const getExePath: any = require(
+    path.join(path.dirname(fileURLToPath(tsgoModuleUrl)), 'getExePath.js'),
+  )
+  const tsserverPath = (
+    typeof getExePath === 'function' ? getExePath : getExePath.default
+  )()
   const { snapshot } = await rolldownBuild(
     path.resolve(dirname, 'fixtures/basic.ts'),
     [
       dts({
         generator: 'tsgo',
-        tsgo: { path: tsgoPath },
+        tsgo: { moduleUrl: tsgoModuleUrl, path: tsserverPath },
         tsconfig: path.resolve(dirname, 'fixtures/basic.tsconfig.json'),
       }),
     ],
   )
   expect(snapshot).toMatchSnapshot()
+})
+
+test('tsgo vfs uses transformed source code', async () => {
+  const input = path.resolve(dirname, 'fixtures/basic.ts')
+  const tsconfig = path.resolve(dirname, 'fixtures/basic.tsconfig.json')
+  const transform = {
+    name: 'transform-before-dts',
+    transform: {
+      order: 'pre' as const,
+      handler(code: string, id: string) {
+        if (id !== input) return
+        return code.replace(
+          'export const foo: number = 42',
+          "export const foo: 'transformed' = 'transformed'",
+        )
+      },
+    },
+  }
+
+  const disk = await rolldownBuild(input, [
+    transform,
+    dts({
+      generator: 'tsgo',
+      tsgo: { moduleUrl: tsgoModuleUrl },
+      tsconfig,
+      emitDtsOnly: true,
+    }),
+  ])
+  const virtual = await rolldownBuild(input, [
+    transform,
+    dts({
+      generator: 'tsgo',
+      tsconfig,
+      emitDtsOnly: true,
+      tsgo: { moduleUrl: tsgoModuleUrl, vfs: true },
+    }),
+  ])
+
+  expect(disk.snapshot).toContain('foo: number')
+  expect(disk.snapshot).not.toContain("foo: 'transformed'")
+  expect(virtual.snapshot).toContain("foo: 'transformed'")
 })
 
 // https://github.com/sxzz/rolldown-plugin-dts/issues/136

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { normalizePath, rolldownBuild } from '@sxzz/test-utils'
 import { describe, expect, test } from 'vitest'
-import { dts } from '../src/index.ts'
+import { dts, type Generator } from '../src/index.ts'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
@@ -15,6 +15,38 @@ test('basic', async () => {
     [dts()],
   )
   expect(snapshot).toMatchSnapshot()
+})
+
+test('custom generator', async () => {
+  const calls: string[] = []
+  const generator: Generator = {
+    init() {
+      calls.push('init')
+    },
+    addFile(_code, fileName) {
+      calls.push(`addFile:${path.basename(fileName)}`)
+    },
+    emit(_code, fileName) {
+      calls.push(`emit:${path.basename(fileName)}`)
+      return { code: 'export declare const custom: true' }
+    },
+    dispose() {
+      calls.push('dispose')
+    },
+  }
+
+  const { snapshot } = await rolldownBuild(
+    path.resolve(dirname, 'fixtures/basic.ts'),
+    [dts({ generator, tsconfig: false, emitDtsOnly: true })],
+  )
+
+  expect(snapshot).toContain('declare const custom: true')
+  expect(calls).toStrictEqual([
+    'init',
+    'addFile:basic.ts',
+    'emit:basic.ts',
+    'dispose',
+  ])
 })
 
 test('tsx', async () => {

--- a/tests/source-map.test.ts
+++ b/tests/source-map.test.ts
@@ -12,6 +12,7 @@ const tsconfig = path.resolve(
   import.meta.dirname,
   'fixtures/source-map/tsconfig.json',
 )
+const tsgoModuleUrl = import.meta.resolve('typescript-next')
 
 beforeAll(async () => {
   await rm(tempDir, { recursive: true, force: true })
@@ -82,6 +83,7 @@ test('tsgo', async () => {
     plugins: [
       dts({
         generator: 'tsgo',
+        tsgo: { moduleUrl: tsgoModuleUrl },
         tsconfig,
         sourcemap: true,
         emitDtsOnly: true,

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -148,7 +148,7 @@ describe('tsc', () => {
       [
         dts({
           tsconfig: path.resolve(root, 'tsconfig.json'),
-          build: true,
+          tsc: { build: true },
           sourcemap: true,
           emitDtsOnly: true,
         }),

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -33,7 +33,7 @@ describe('tsc', () => {
   test('parallel', async () => {
     const { snapshot } = await rolldownBuild(
       path.resolve(dirname, 'fixtures/basic.ts'),
-      [dts({ generator: 'tsc', parallel: true })],
+      [dts({ generator: 'tsc', tsc: { parallel: true } })],
     )
     expect(snapshot).toContain('export declare const foo: number;')
   })
@@ -60,7 +60,7 @@ describe('tsc', () => {
         dts({
           tsconfig: path.resolve(root, 'tsconfig.json'),
           compilerOptions: { isolatedDeclarations: false },
-          build: true,
+          tsc: { build: true },
         }),
       ],
     )
@@ -76,7 +76,7 @@ describe('tsc', () => {
         dts({
           tsconfig: path.resolve(root, 'tsconfig.json'),
           sourcemap: true,
-          build: false,
+          tsc: { build: false },
         }),
       ],
       {},
@@ -100,7 +100,7 @@ describe('tsc', () => {
         dts({
           tsconfig: path.resolve(root, 'tsconfig.json'),
           sourcemap: true,
-          build: true,
+          tsc: { build: true },
         }),
       ],
       {},
@@ -124,7 +124,7 @@ describe('tsc', () => {
       [
         dts({
           tsconfig: path.resolve(root, 'tsconfig.react.json'),
-          build: true,
+          tsc: { build: true },
           sourcemap: true,
           emitDtsOnly: true,
         }),
@@ -180,7 +180,7 @@ describe('tsc', () => {
         dts({
           tsconfig: path.resolve(root, 'tsconfig.json'),
           compilerOptions: { isolatedDeclarations: false },
-          build: true,
+          tsc: { build: true },
         }),
       ],
     )
@@ -213,7 +213,7 @@ describe('tsc', () => {
         dts({
           tsconfig: path.resolve(root, 'tsconfig.json'),
           compilerOptions: { isolatedDeclarations: false },
-          build: true,
+          tsc: { build: true },
         }),
       ],
     )

--- a/tests/tsgo.test.ts
+++ b/tests/tsgo.test.ts
@@ -43,7 +43,6 @@ test('vfs accumulates files, applies changes, and resets between builds', async 
   expect(changed.code).toContain('valueB: "changed-b"')
 
   await generator.dispose()
-  generator = createGenerator()
   await generator.init()
 
   const rebuilt = await generator.emit(aCode, a)

--- a/tests/tsgo.test.ts
+++ b/tests/tsgo.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+import { LanguageContext } from '../src/custom-language.ts'
+import { TsgoGenerator } from '../src/generator/tsgo.ts'
+
+const root = path.resolve(import.meta.dirname, 'fixtures/tsgo-vfs')
+const moduleUrl = import.meta.resolve('typescript-next')
+const tsconfig = path.join(root, 'tsconfig.json')
+const a = path.join(root, 'a.ts')
+const b = path.join(root, 'b.ts')
+
+let generator: TsgoGenerator | undefined
+
+afterEach(async () => {
+  await generator?.dispose()
+  generator = undefined
+})
+
+function createGenerator(): TsgoGenerator {
+  return new TsgoGenerator({
+    moduleUrl,
+    cwd: root,
+    tsconfig,
+    vfs: true,
+    languageContext: new LanguageContext([]),
+  })
+}
+
+test('vfs accumulates files, applies changes, and resets between builds', async () => {
+  const aCode = await readFile(a, 'utf8')
+  generator = createGenerator()
+  await generator.init()
+
+  generator.addFile("export const valueB = 'virtual-b' as const\n", b)
+  const first = await generator.emit(aCode, a)
+  expect(first.error).toBeUndefined()
+  expect(first.code).toContain('valueB: "virtual-b"')
+
+  await generator.emit("export const valueB = 'changed-b' as const\n", b)
+  const changed = await generator.emit(aCode, a)
+  expect(changed.error).toBeUndefined()
+  expect(changed.code).toContain('valueB: "changed-b"')
+
+  await generator.dispose()
+  generator = createGenerator()
+  await generator.init()
+
+  const rebuilt = await generator.emit(aCode, a)
+  expect(rebuilt.error).toBeUndefined()
+  expect(rebuilt.code).toContain('valueB: number')
+})


### PR DESCRIPTION
## Summary

- replace the tsgo CLI implementation with the asynchronous declaration emit API
- add `tsgo.moduleUrl`, defaulting to `import.meta.resolve("typescript")`, with capability-based API detection
- add opt-in VFS support so tsgo can emit declarations from Rolldown-transformed code
- update generator inference, dependencies, documentation, API snapshots, and test coverage

## Testing

- `pnpm vitest run` (280 passed, 1 expected failure)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`