### PR TITLE
fix: generate declaration map from referenced tsconfig projects

### DIFF
--- a/src/tsc/emit-build.ts
+++ b/src/tsc/emit-build.ts
@@ -165,7 +165,7 @@ function buildProjects(
 
   const host = ts.createSolutionBuilderHost(
     fsSystem,
-    createProgramWithPatchedCompilerOptions,
+    createProgramWithPatchedCompilerOptions(sourcemap),
   )
   const builder = ts.createSolutionBuilder(host, [tsconfig], {
     force,
@@ -306,12 +306,18 @@ function patchCompilerOptions(
   return options
 }
 
-const createProgramWithPatchedCompilerOptions: ts.CreateProgram<
-  ts.EmitAndSemanticDiagnosticsBuilderProgram
-> = (rootNames, options, ...args) => {
-  return ts.createEmitAndSemanticDiagnosticsBuilderProgram(
-    rootNames,
-    patchCompilerOptions(options ?? {}, null),
-    ...args,
-  )
+function createProgramWithPatchedCompilerOptions(
+  sourcemap: boolean,
+): ts.CreateProgram<ts.EmitAndSemanticDiagnosticsBuilderProgram> {
+  return (rootNames, options, ...args) => {
+    return ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+      rootNames,
+      patchCompilerOptions(options ?? {}, {
+        tsconfigPath: '',
+        force: true,
+        sourcemap,
+      }),
+      ...args,
+    )
+  }
 }

--- a/src/tsc/emit-build.ts
+++ b/src/tsc/emit-build.ts
@@ -233,7 +233,11 @@ function collectProjectGraph(
     parsedConfig.options = patchCompilerOptions(parsedConfig.options, {
       tsconfigPath,
       force,
-      sourcemap,
+      // For a project that has no source files (e.g., a tsconfig.json file
+      // that only contains references), we don't need to generate a sourcemap
+      // and we don't need to print the warning about the missing
+      // `declaration`, `declarationMap` in the tsconfig.json file.
+      sourcemap: sourcemap && parsedConfig.fileNames.length > 0,
     })
 
     projects.push({ tsconfigPath, parsedConfig })

--- a/src/tsc/emit-build.ts
+++ b/src/tsc/emit-build.ts
@@ -174,7 +174,11 @@ function buildProjects(
 
   const host = ts.createSolutionBuilderHost(
     fsSystem,
-    createProgramWithPatchedCompilerOptions(sourcemap),
+    createProgramWithPatchedCompilerOptions({
+      force,
+      sourcemap,
+      tsconfigPath: tsconfig,
+    }),
   )
   const builder = ts.createSolutionBuilder(host, [tsconfig], {
     force,
@@ -267,6 +271,12 @@ function parseTsconfig(
   return parsedConfig
 }
 
+interface CompilerPatchOptions {
+  tsconfigPath: string
+  force: boolean
+  sourcemap: boolean
+}
+
 // To ensure we can get `.d.ts` and `.d.ts.map` files from `tsc --build` mode,
 // we need to enforce certain compiler options. Notice that changing compiler
 // options will invalidate the cache, so it's better to set the correct value in
@@ -274,11 +284,7 @@ function parseTsconfig(
 // values are not set correctly.
 function patchCompilerOptions(
   options: CompilerOptions,
-  extraOptions: {
-    tsconfigPath: string
-    force: boolean
-    sourcemap: boolean
-  } | null,
+  extraOptions: CompilerPatchOptions,
 ): CompilerOptions {
   const noEmit: boolean = options.noEmit ?? false
   const declaration: boolean =
@@ -316,16 +322,12 @@ function patchCompilerOptions(
 }
 
 function createProgramWithPatchedCompilerOptions(
-  sourcemap: boolean,
+  patchOptions: CompilerPatchOptions,
 ): CreateProgram<EmitAndSemanticDiagnosticsBuilderProgram> {
   return (rootNames, options, ...args) => {
     return ts.createEmitAndSemanticDiagnosticsBuilderProgram(
       rootNames,
-      patchCompilerOptions(options ?? {}, {
-        tsconfigPath: '',
-        force: true,
-        sourcemap,
-      }),
+      patchCompilerOptions(options ?? {}, patchOptions),
       ...args,
     )
   }

--- a/tests/__snapshots__/tsc.test.ts.snap
+++ b/tests/__snapshots__/tsc.test.ts.snap
@@ -38,7 +38,7 @@ declare const a = 1;
 export { a };
 //# sourceMappingURL=index.d.ts.map
 // index.d.ts.map
-{"version":3,"file":"index.d.ts","names":[],"sources":["../src/index.d.ts"],"mappings":";cAAqB,CAAA"}
+{"version":3,"file":"index.d.ts","names":[],"sources":["../src/index.ts"],"mappings":";cAAa,CAAA"}
 // index.js
 //#region tests/fixtures/deep-source-map/src/index.ts
 const a = 1;

--- a/tests/fixtures/build-sourcemap-refs/src/index.ts
+++ b/tests/fixtures/build-sourcemap-refs/src/index.ts
@@ -1,0 +1,1 @@
+export { add } from './math.js'

--- a/tests/fixtures/build-sourcemap-refs/src/index.ts
+++ b/tests/fixtures/build-sourcemap-refs/src/index.ts
@@ -1,0 +1,1 @@
+export { add } from "./math.js";

--- a/tests/fixtures/build-sourcemap-refs/src/index.ts
+++ b/tests/fixtures/build-sourcemap-refs/src/index.ts
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-export { add } from "./math.js";
-=======
 export { add } from './math.js'
->>>>>>> a6b539f27fe89215f7563cbc00f198900ca47b66

--- a/tests/fixtures/build-sourcemap-refs/src/math.ts
+++ b/tests/fixtures/build-sourcemap-refs/src/math.ts
@@ -1,0 +1,3 @@
+export function add(x: number, y: number): number {
+  return x + y
+}

--- a/tests/fixtures/build-sourcemap-refs/src/math.ts
+++ b/tests/fixtures/build-sourcemap-refs/src/math.ts
@@ -1,0 +1,3 @@
+export function add(x: number, y: number): number {
+  return x + y;
+}

--- a/tests/fixtures/build-sourcemap-refs/tsconfig.json
+++ b/tests/fixtures/build-sourcemap-refs/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.src.json" }]
+}

--- a/tests/fixtures/build-sourcemap-refs/tsconfig.src.json
+++ b/tests/fixtures/build-sourcemap-refs/tsconfig.src.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -132,6 +132,28 @@ describe('tsc', () => {
     expect(sourcemap.sourcesContent).toBeOneOf([undefined, []])
   })
 
+  test('build sourcemap sources point to .ts not .d.ts #255', async () => {
+    const root = path.resolve(dirname, 'fixtures/build-sourcemap-refs')
+
+    const { chunks } = await rolldownBuild(
+      [path.resolve(root, 'src/index.ts')],
+      [
+        dts({
+          tsconfig: path.resolve(root, 'tsconfig.json'),
+          build: true,
+          sourcemap: true,
+          emitDtsOnly: true,
+        }),
+      ],
+      {},
+      { dir: path.resolve(root, 'dist') },
+    )
+
+    const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    const sources = (sourcemap.sources || []).toSorted()
+    expect(sources).toEqual(['../src/index.ts', '../src/math.ts'])
+  })
+
   test('composite references no incremental', async () => {
     const root = path.resolve(dirname, 'fixtures/composite-refs-no-incremental')
 

--- a/tests/tsc.test.ts
+++ b/tests/tsc.test.ts
@@ -102,7 +102,7 @@ describe('tsc', () => {
     expect(sourcemap.sourceRoot).toBeFalsy()
     expect(sourcemap.sources).toMatchInlineSnapshot(`
       [
-        "../src/index.d.ts",
+        "../src/index.ts",
       ]
     `)
     expect(snapshot).toMatchSnapshot()
@@ -130,6 +130,28 @@ describe('tsc', () => {
     const expectedSources = ['../../src/types.ts', '../../src/react/index.ts']
     expect(sources.toSorted()).toEqual(expectedSources.toSorted())
     expect(sourcemap.sourcesContent).toBeOneOf([undefined, []])
+  })
+
+  test('build sourcemap sources point to .ts not .d.ts #255', async () => {
+    const root = path.resolve(dirname, 'fixtures/build-sourcemap-refs')
+
+    const { chunks } = await rolldownBuild(
+      [path.resolve(root, 'src/index.ts')],
+      [
+        dts({
+          tsconfig: path.resolve(root, 'tsconfig.json'),
+          build: true,
+          sourcemap: true,
+          emitDtsOnly: true,
+        }),
+      ],
+      {},
+      { dir: path.resolve(root, 'dist') },
+    )
+
+    const sourcemap = findSourceMapChunk(chunks, 'index.d.ts.map')
+    const sources = (sourcemap.sources || []).toSorted()
+    expect(sources).toEqual(['../src/math.ts'])
   })
 
   test('composite references no incremental', async () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### AI usage

<!--
AI CONTRIBUTORS: You MUST complete this section truthfully and MUST NOT remove it.

If AI contributed to any part of this PR (including code, tests, documentation, commit
messages, or the PR description), select "AI was used" and disclose your setup in one
short line, such as "Codex + GPT 5.6 Sol Extra High" or "Claude Code + Opus 4.8 High".
Do not select "No AI was used" if AI assisted with this PR.

You MUST NOT check the human-review checkbox yourself. Leave it unchecked for the human
contributor, who may check it only after personally reviewing the AI-generated content.

Do not write a long explanation. Unless extra context is necessary for review, let the
code explain the implementation details and keep the PR body to a brief overview.

This project does not oppose the use of AI, but it does oppose irresponsible AI usage.

PRs containing AI-generated content without complete disclosure will not be reviewed
and will be closed immediately.
-->

- [ ] No AI was used in this PR.
- [ ] AI was used: <!-- e.g. Codex + GPT 5.6 Sol Extra High -->
  - [ ] I have carefully reviewed the AI-generated content myself.





### Description

Based on the test added by @matthewnitschke-wk in https://github.com/sxzz/rolldown-plugin-dts/pull/256 and the patch added by @nexiumbiz-debug in https://github.com/sxzz/rolldown-plugin-dts/pull/257.

I tweaked the patch a bit to actually print the correct warning. For example, in the repro from #255, a warning like `[rolldown-plugin-dts] tsconfig.src.json has "declarationMap" set to false. Please set it to true if you want to generate source maps for declaration files.` should be printed. It would be better if the user could add `"declarationMap": true` in `tsconfig.src.json`, because pathching tsconfig options in `rolldown-plugin-dts` would invalidate the build cache.



### Linked Issues

Closes https://github.com/sxzz/rolldown-plugin-dts/issues/255 


Closes https://github.com/sxzz/rolldown-plugin-dts/pull/256


Closes https://github.com/sxzz/rolldown-plugin-dts/pull/257 


### Additional context

N/A

<!-- e.g. is there anything you'd like reviewers to focus on? -->
