### PR TITLE
fix: only warn about tsconfig files that emit declarations

### DIFF
--- a/src/tsc/emit-build.ts
+++ b/src/tsc/emit-build.ts
@@ -177,10 +177,7 @@ function buildProjects(
     createProgramWithPatchedCompilerOptions({
       force,
       sourcemap,
-      // The solution builder invokes this for each referenced project, but
-      // hands us its compiler options without telling us which tsconfig file
-      // they came from. `collectProjectGraph` has already warned about the
-      // whole graph, so patch silently here rather than name the wrong file.
+      /** we don't need to print warning here because we have done this in {@link collectProjectGraph} */
       tsconfigPath: null,
     }),
   )

--- a/src/tsc/emit-build.ts
+++ b/src/tsc/emit-build.ts
@@ -177,7 +177,11 @@ function buildProjects(
     createProgramWithPatchedCompilerOptions({
       force,
       sourcemap,
-      tsconfigPath: tsconfig,
+      // The solution builder invokes this for each referenced project, but
+      // hands us its compiler options without telling us which tsconfig file
+      // they came from. `collectProjectGraph` has already warned about the
+      // whole graph, so patch silently here rather than name the wrong file.
+      tsconfigPath: null,
     }),
   )
   const builder = ts.createSolutionBuilder(host, [tsconfig], {
@@ -231,13 +235,12 @@ function collectProjectGraph(
     if (!parsedConfig) continue
 
     parsedConfig.options = patchCompilerOptions(parsedConfig.options, {
-      tsconfigPath,
+      // A project without source files (e.g. a tsconfig.json file that only
+      // contains references) emits no declaration files, so there is nothing
+      // for the user to fix in it. Pass `null` to patch it without warning.
+      tsconfigPath: parsedConfig.fileNames.length > 0 ? tsconfigPath : null,
       force,
-      // For a project that has no source files (e.g., a tsconfig.json file
-      // that only contains references), we don't need to generate a sourcemap
-      // and we don't need to print the warning about the missing
-      // `declaration`, `declarationMap` in the tsconfig.json file.
-      sourcemap: sourcemap && parsedConfig.fileNames.length > 0,
+      sourcemap,
     })
 
     projects.push({ tsconfigPath, parsedConfig })
@@ -276,7 +279,8 @@ function parseTsconfig(
 }
 
 interface CompilerPatchOptions {
-  tsconfigPath: string
+  // The tsconfig file to name in the warnings, or `null` to patch silently.
+  tsconfigPath: string | null
   force: boolean
   sourcemap: boolean
 }


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
  - [x] I have carefully reviewed the AI-generated content myself.

Claude Code + Opus 5 High.

### Description

Follow-up to #291: a solution-style `tsconfig.json` no longer gets warned about, and the warning from the solution builder no longer names the wrong file.

### Linked Issues

N/A

### Additional context

`#291` gated `sourcemap` on `parsedConfig.fileNames.length`, which only suppresses the `declarationMap` warning. The `declaration` warning is not gated by `sourcemap`, so a solution root that only holds `references` was still told to set `declaration: true`, where it has no effect. Gating `tsconfigPath` instead covers all three warnings and leaves the computed compiler options alone.

The `createProgram` callback also passed the root `tsconfigPath`, but the solution builder calls it once per referenced project, so it reported `tsconfig.json` for a problem in `tsconfig.src.json`. `collectProjectGraph` walks the same graph and already warns with the right path, so this passes `null` now.
