### PR TITLE
fix: resolve types re-exported from external packages through inlined modules

### DIFF
--- a/src/fake-js/index.ts
+++ b/src/fake-js/index.ts
@@ -425,7 +425,8 @@ export function createFakeJsPlugin({
 
     const { program } = file
     program.body = patchTsNamespace(program.body)
-    program.body = patchReExport(program.body)
+    const reExportTargets = new Map<string, string>()
+    program.body = patchReExport(program.body, reExportTargets)
 
     const exportPlan = planChunkExports(
       chunk,
@@ -515,6 +516,18 @@ export function createFakeJsPlugin({
           transformedDep = undefinedDep
         } else if (isInfer(transformedDep)) {
           transformedDep.name = '__Infer'
+        } else if (
+          transformedDep.type === 'MemberExpression' &&
+          !transformedDep.computed &&
+          transformedDep.object.type === 'Identifier' &&
+          transformedDep.property.type === 'Identifier'
+        ) {
+          // `X_exports.A` only exists via `__reExport(X_exports, import_lib)`,
+          // so reference `import_lib.A` instead.
+          const target = reExportTargets.get(transformedDep.object.name)
+          if (target && target !== transformedDep.object.name) {
+            transformedDep.object.name = target
+          }
         }
 
         if (originalDep.replace) {

--- a/src/fake-js/patch.ts
+++ b/src/fake-js/patch.ts
@@ -168,12 +168,13 @@ function getExportAllNamespace(
 
 /**
  * Handle `__reExport` call
+ *
+ * Pass `exportsNames` to collect the `X_exports -> import_lib` mappings.
  */
 export function patchReExport(
   nodes: t.ProgramStatement[],
+  exportsNames: Map<string, string> = new Map(),
 ): t.ProgramStatement[] {
-  const exportsNames = new Map<string, string>()
-
   for (const [i, node] of nodes.entries()) {
     if (
       node.type === 'ImportDeclaration' &&

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -246,6 +246,23 @@ export declare class Foo {}
 //#endregion"
 `;
 
+exports[`dts input > type imported via local module re-exporting an external package 1`] = `
+"// index.d.ts
+import { WidgetProps } from "some-pkg";
+declare namespace wrapper_d_exports {
+  export { Wrapper as default };
+}
+import * as import_some_pkg from "some-pkg";
+declare const Wrapper: (props: WidgetProps) => null;
+//#endregion
+//#region tests/fixtures/dts-input-reexport-external/index.d.ts
+export interface ConsumerProps extends Omit<import_some_pkg.WidgetProps, 'id'> {
+  id: string;
+}
+export declare function Consumer(props: ConsumerProps): null;
+//#endregion"
+`;
+
 exports[`entryFileNames > custom chunk name 2`] = `
 "// chunks/D2aRkv2b-types.d.ts
 //#region tests/fixtures/dts-multi-input/types.d.ts

--- a/tests/fixtures/dts-input-reexport-external/index.d.ts
+++ b/tests/fixtures/dts-input-reexport-external/index.d.ts
@@ -1,0 +1,5 @@
+import { WidgetProps } from './wrapper'
+export interface ConsumerProps extends Omit<WidgetProps, 'id'> {
+  id: string
+}
+export declare function Consumer(props: ConsumerProps): null

--- a/tests/fixtures/dts-input-reexport-external/wrapper.d.ts
+++ b/tests/fixtures/dts-input-reexport-external/wrapper.d.ts
@@ -1,0 +1,4 @@
+import { WidgetProps } from 'some-pkg'
+declare const Wrapper: (props: WidgetProps) => null
+export { Wrapper as default }
+export * from 'some-pkg'

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -147,6 +147,17 @@ test('tree-shaking', async () => {
 })
 
 describe('dts input', () => {
+  test('type imported via local module re-exporting an external package', async () => {
+    const root = path.resolve(dirname, 'fixtures/dts-input-reexport-external')
+    const { snapshot, chunks } = await rolldownBuild(
+      [path.join(root, 'index.d.ts')],
+      [dts({ dtsInput: true })],
+      { external: 'some-pkg' },
+    )
+    expect(chunks[0].code).not.toContain('wrapper_d_exports.WidgetProps')
+    expect(snapshot).toMatchSnapshot()
+  })
+
   test('input array', async () => {
     const { snapshot, chunks } = await rolldownBuild(
       [path.resolve(dirname, 'fixtures/dts-input.d.ts')],


### PR DESCRIPTION
Fixes #300

### Problem

With `dtsInput: true`, when an entry imports a type from a local module that only
provides it via `export * from 'some-pkg'`, the bundled output references
`module_d_exports.Type` — a member the generated namespace doesn't have.

The failure is silent: with `skipLibCheck` (most apps) the type just becomes `any`,
and consumers only notice later, e.g. as `TS7006` on callback parameters. Without
`skipLibCheck` it's `TS2694: Namespace 'wrapper_d_exports' has no exported member
'WidgetProps'`.

### Reproduction

```ts
// wrapper.d.ts
import { WidgetProps } from 'some-pkg'
declare const Wrapper: (props: WidgetProps) => null
export { Wrapper as default }
export * from 'some-pkg'
```

```ts
// index.d.ts
import { WidgetProps } from './wrapper'
export interface ConsumerProps extends Omit<WidgetProps, 'id'> {
  id: string
}
```

Bundled with `dts({ dtsInput: true })` and `some-pkg` external, before this change:

```ts
declare namespace wrapper_d_exports {
  export { Wrapper as default };        // <- no WidgetProps here
}
import * as import_some_pkg from "some-pkg";

export interface ConsumerProps extends Omit<wrapper_d_exports.WidgetProps, 'id'> {
                                        // ^ dangling
```

### Fix

Rolldown emits the namespace-member form exactly when a name is only reachable
through `__reExport(X_exports, import_lib)` (it resolves statically-known members
to direct bindings). `patchReExport` already collects the `X_exports -> import_lib`
mapping and uses it for statement patterns (`var B = a_exports.A`); this PR exposes
that map and applies it to member-expression deps when grafting rolldown's renamed
references back into type positions:

```ts
export interface ConsumerProps extends Omit<import_some_pkg.WidgetProps, 'id'> {
```

Scope note: this covers the named-import path (`import { WidgetProps } from
'./wrapper'`). A namespace import (`import * as W from './wrapper'` + `W.WidgetProps`)
is a different dep shape and keeps its current behavior, matching the existing TODO
in `patchReExport`.

Found in a real build: a design-system component imported `MenuProps` from a local
`Menu` wrapper re-exporting `@mui/material/Menu`; every downstream app silently lost
typing on those props.

Full suite passes with no other snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

