### PR TITLE
fix(fake-js): do not collect type-only exports for non-facade chunks

### DIFF
--- a/src/fake-js/exports.ts
+++ b/src/fake-js/exports.ts
@@ -214,11 +214,16 @@ function collectChunkExports(
   chunk: RenderedChunk,
   moduleExportsMap: Map<string, ModuleExports>,
 ): ChunkExports {
+  if (!chunk.facadeModuleId || !moduleExportsMap.has(chunk.facadeModuleId)) {
+    return {
+      typeOnlyNames: new Set(),
+      typeOnlyExportAllSources: new Set(),
+      inlineNames: new Set(),
+    }
+  }
+
   const exportsByModule = resolveAllModuleExports(moduleExportsMap)
-  const roots =
-    chunk.facadeModuleId && moduleExportsMap.has(chunk.facadeModuleId)
-      ? [chunk.facadeModuleId]
-      : chunk.moduleIds
+  const roots = [chunk.facadeModuleId]
   const mergedExports = new Map<string, boolean>()
   const typeOnlyExportAllSources = new Set<string>()
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -37,6 +37,20 @@ export { Cls, Enum, fn, foo };
 "
 `;
 
+exports[`chunk alias type collision 1`] = `
+"// entry.d.ts
+import { n as fn, t as n } from "./shared-chunk-BiIeNIrJ.js";
+export { fn, type n };
+// shared-chunk-BiIeNIrJ.d.ts
+//#region tests/fixtures/chunk-alias-type-collision/shared.d.ts
+declare const fn: () => string;
+//#endregion
+//#region tests/fixtures/chunk-alias-type-collision/types.d.ts
+type n = string;
+//#endregion
+export { fn as n, n as t };"
+`;
+
 exports[`cjs exports 1`] = `
 "// cjs-exports.js
 //#region tests/fixtures/cjs-exports.ts

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -37,7 +37,7 @@ export { Cls, Enum, fn, foo };
 "
 `;
 
-exports[`chunk alias type collision 1`] = `
+exports[`chunk alias type collision > minified internal exports 1`] = `
 "// entry.d.ts
 import { n as fn, t as n } from "./shared-chunk-BiIeNIrJ.js";
 export { fn, type n };
@@ -49,6 +49,20 @@ declare const fn: () => string;
 type n = string;
 //#endregion
 export { fn as n, n as t };"
+`;
+
+exports[`chunk alias type collision > original internal exports 1`] = `
+"// entry.d.ts
+import { fn, n } from "./shared-chunk-B9gKTuoj.js";
+export { fn, type n };
+// shared-chunk-B9gKTuoj.d.ts
+//#region tests/fixtures/chunk-alias-type-collision/shared.d.ts
+declare const fn: () => string;
+//#endregion
+//#region tests/fixtures/chunk-alias-type-collision/types.d.ts
+type n = string;
+//#endregion
+export { fn, n };"
 `;
 
 exports[`cjs exports 1`] = `

--- a/tests/fixtures/chunk-alias-type-collision/entry.ts
+++ b/tests/fixtures/chunk-alias-type-collision/entry.ts
@@ -1,0 +1,2 @@
+export * from './shared'
+export * from './types'

--- a/tests/fixtures/chunk-alias-type-collision/shared.ts
+++ b/tests/fixtures/chunk-alias-type-collision/shared.ts
@@ -1,0 +1,1 @@
+export const fn = () => 'value'

--- a/tests/fixtures/chunk-alias-type-collision/types.ts
+++ b/tests/fixtures/chunk-alias-type-collision/types.ts
@@ -1,0 +1,2 @@
+type n = string
+export type { n }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -578,6 +578,21 @@ test('codeSplitting', async () => {
   expect(chunks).toHaveLength(2)
 })
 
+test('chunk alias type collision', async () => {
+  const { snapshot, chunks } = await rolldownBuild(
+    path.resolve(dirname, 'fixtures/chunk-alias-type-collision/entry.ts'),
+    [dts({ emitDtsOnly: true })],
+    {},
+    {
+      codeSplitting: {
+        groups: [{ test: /(shared|types)/, name: 'shared-chunk.d' }],
+      },
+    },
+  )
+  expect(snapshot).toMatchSnapshot()
+  expect(chunks).toHaveLength(2)
+})
+
 test('re-export from lib', async () => {
   const cwd = path.resolve(dirname, 'fixtures/re-export-lib')
   const { snapshot: onlyA } = await rolldownBuild(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -597,6 +597,7 @@ describe('chunk alias type collision', () => {
     expect(snapshot).toMatchSnapshot()
     expect(chunks).toHaveLength(2)
     // `fn` leaves the shared chunk under the alias `n`, the name of a type
+    expect(snapshot).toContain('fn as n')
     expect(snapshot).not.toContain('type fn as n')
     expect(snapshot).toContain('export { fn, type n }')
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -578,19 +578,40 @@ test('codeSplitting', async () => {
   expect(chunks).toHaveLength(2)
 })
 
-test('chunk alias type collision', async () => {
-  const { snapshot, chunks } = await rolldownBuild(
-    path.resolve(dirname, 'fixtures/chunk-alias-type-collision/entry.ts'),
-    [dts({ emitDtsOnly: true })],
-    {},
-    {
-      codeSplitting: {
-        groups: [{ test: /(shared|types)/, name: 'shared-chunk.d' }],
-      },
-    },
+describe('chunk alias type collision', () => {
+  const entry = path.resolve(
+    dirname,
+    'fixtures/chunk-alias-type-collision/entry.ts',
   )
-  expect(snapshot).toMatchSnapshot()
-  expect(chunks).toHaveLength(2)
+  const codeSplitting = {
+    groups: [{ test: /(shared|types)/, name: 'shared-chunk.d' }],
+  }
+
+  test('minified internal exports', async () => {
+    const { snapshot, chunks } = await rolldownBuild(
+      entry,
+      [dts({ emitDtsOnly: true })],
+      {},
+      { codeSplitting },
+    )
+    expect(snapshot).toMatchSnapshot()
+    expect(chunks).toHaveLength(2)
+    // `fn` leaves the shared chunk under the alias `n`, the name of a type
+    expect(snapshot).not.toContain('type fn as n')
+    expect(snapshot).toContain('export { fn, type n }')
+  })
+
+  test('original internal exports', async () => {
+    const { snapshot, chunks } = await rolldownBuild(
+      entry,
+      [dts({ emitDtsOnly: true })],
+      {},
+      { codeSplitting, minifyInternalExports: false },
+    )
+    expect(snapshot).toMatchSnapshot()
+    expect(chunks).toHaveLength(2)
+    expect(snapshot).toContain('export { fn, type n }')
+  })
 })
 
 test('re-export from lib', async () => {


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
- [x] AI was used: Cursor agent (Gemini 3.8 Flash High for the fix, Claude Fable 5.1 Thinking for the tests and verification)
  - [x] I have carefully reviewed the AI-generated content myself.

### Description

In non-facade (shared) chunks, export specifiers use Rolldown-generated mangled aliases (e.g. `export { UserAvatar as Id }`). Previously, `collectChunkExports` fell back to `chunk.moduleIds` when `chunk.facadeModuleId` was null, so `typeOnlyNames` held the *original* names of every type exported by any module in the chunk, while the specifiers it was matched against carry *aliases*. If a generated alias happened to equal a type name (such as `type Id = string`), the alias was stamped with `type` in `patchImportExport`. This marked unrelated value declarations as `export type` (e.g. `export { type UserAvatar as Id }`), breaking consumers with TS1362 (`'UserAvatar' cannot be used as a value because it was exported using 'export type'`).

Non-facade chunks are internal to the bundle and only imported by other chunks in the same bundle. Facade chunks apply their own type-only export modifiers at their boundary, so non-facade chunks no longer get a type-only export plan.

Credit to @tillschweneker for the investigation in https://github.com/sanity-io/sanity/issues/14509.

### Behavior change for `minifyInternalExports: false`

Shared chunks now emit `declare const fn` + `export { fn, n }` instead of `export declare const fn` + `export type { n }`. Inline `export` re-attachment and the `type` modifier are skipped for shared chunks under both settings; the facade still emits `export { fn, type n }`. The second test below pins this so the change is visible in the snapshot. Consumers typecheck identically under `verbatimModuleSyntax` + `isolatedModules` with `skipLibCheck: false`.

### Linked Issues

Reported in https://github.com/sanity-io/sanity/issues/14509

### Additional context

Tests in `tests/index.test.ts` (`chunk alias type collision`):

- `minified internal exports`: the fixture picks a type named `n` so Rolldown's alias for the value `fn` collides with it. Asserts the collision is present (`fn as n` in the shared chunk, so an alias-order change in Rolldown breaks the test instead of making it vacuous), that it carries no `type` modifier, and that the facade keeps `export { fn, type n }`. Fails on `main` with `export { type fn as n, n as t }`.
- `original internal exports`: same fixture with `minifyInternalExports: false`, snapshot only.

Verified against the real artifact: rebuilding `sanity` (22 `.d.ts` files, multi-entry, 1155 type-only specifiers) with this patch applied to the installed plugin changes exactly one specifier in one shared chunk, `type operationEvents as Id` → `operationEvents as Id`; every facade is byte-identical. A TypeScript-API scan that resolves each type-only specifier to its symbol reports 1 mis-marked value before and 0 after.

`pnpm test`, `pnpm typecheck`, `pnpm lint`, and `pnpm build` pass.
