### PR TITLE
fix: keep namespace members from conflicting with bundled references

### DIFF
--- a/src/fake-js/README.md
+++ b/src/fake-js/README.md
@@ -68,6 +68,44 @@ var [binding, ...] = [declarationId, (typeParam, ...) => [dep, ...], ["child", .
 | children array  | One empty string literal per identifier inside the declaration, only used to carry source positions back for sourcemaps.                                                                                           |
 | `sideEffect()`  | Optional. A call to an unresolved global, so that a declaration nothing references — `declare module '...'`, `declare global` — is not tree-shaken away.                                                           |
 
+## Namespace members
+
+A whole `declare namespace N { ... }` is one declaration, so rolldown never
+sees the scope its body opens. Two things follow from that, both handled by the
+plugin itself.
+
+A reference in the body to a member of that namespace is not a dependency. It
+is recorded as a reference to the member instead, so that it neither keeps a
+declaration of the same name around the namespace alive nor follows it when
+rolldown renames it.
+
+And rolldown may rename a reference to something around the namespace to the
+name of a member, which then captures it:
+
+```ts
+import { Foo as OuterFoo } from './foo'
+export declare namespace N {
+  export type Foo = OuterFoo // after bundling: `type Foo = Foo`
+}
+```
+
+`renderChunk` looks for members captured like that, renames them together with
+the references to them, and exports them under their original name:
+
+```ts
+export declare namespace N {
+  type Foo$1 = Foo
+  export { Foo$1 as Foo }
+}
+```
+
+A name only collides within one declaration space of TypeScript: the value
+member of `var Theme: Theme` does not capture the type it is annotated with, so
+both steps compare what a member declares — a type, a value, a namespace — with
+what a reference asks for. Only the direct members of the namespace are tracked,
+and a name that a type parameter or a nested namespace declares again is left
+alone.
+
 ## Export shape
 
 A declaration written as `export declare const x` is emitted as
@@ -107,12 +145,12 @@ Smaller ones:
 
 ## Files
 
-| File                 | Scope                                                                                                                                                                                                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index.ts`           | The plugin. `transform` turns a declaration file into fake JavaScript, `renderChunk` turns a bundled chunk back into declarations, and `declarationMap` connects the two. Also names the `.d.ts` chunks and drops the `.d.ts.map` files when sourcemaps are off. |
-| `exports.ts`         | Everything about the shape of the exports: what each module exports, collected during `transform`, and the `ChunkExportPlan` of a chunk — which names are type only, which declarations get their `export` keyword back, whether `export =` may be emitted.      |
-| `patch.ts`           | Statement rewrites. `rewriteImportExport` prepares imports and exports for bundling, `patchImportExport`, `patchTsNamespace` and `patchReExport` undo that and rolldown's `__exportAll` / `__reExport` helpers afterwards.                                       |
-| `dependency.ts`      | Walks a declaration for what it references: type references, type parameters, and `import('...')` types, which are hoisted into real namespace imports so rolldown can resolve them.                                                                             |
-| `runtime-binding.ts` | The encoding above: the builder and the type guards that recognise it again in a chunk.                                                                                                                                                                          |
-| `utils.ts`           | Small shared AST and comment helpers.                                                                                                                                                                                                                            |
-| `types.ts`           | The types shared across the files.                                                                                                                                                                                                                               |
+| File                 | Scope                                                                                                                                                                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`           | The plugin. `transform` turns a declaration file into fake JavaScript, `renderChunk` turns a bundled chunk back into declarations, and `declarationMap` connects the two. Also names the `.d.ts` chunks and drops the `.d.ts.map` files when sourcemaps are off.                       |
+| `exports.ts`         | Everything about the shape of the exports: what each module exports, collected during `transform`, and the `ChunkExportPlan` of a chunk — which names are type only, which declarations get their `export` keyword back, whether `export =` may be emitted.                            |
+| `patch.ts`           | Statement rewrites. `rewriteImportExport` prepares imports and exports for bundling, `patchImportExport`, `patchTsNamespace` and `patchReExport` undo that and rolldown's `__exportAll` / `__reExport` helpers afterwards, `patchNamespaceMembers` renames captured namespace members. |
+| `dependency.ts`      | Walks a declaration for what it references: type references, type parameters, the members of a namespace, and `import('...')` types, which are hoisted into real namespace imports so rolldown can resolve them.                                                                       |
+| `runtime-binding.ts` | The encoding above: the builder and the type guards that recognise it again in a chunk.                                                                                                                                                                                                |
+| `utils.ts`           | Small shared AST and comment helpers.                                                                                                                                                                                                                                                  |
+| `types.ts`           | The types shared across the files.                                                                                                                                                                                                                                                     |

--- a/src/fake-js/dependency.ts
+++ b/src/fake-js/dependency.ts
@@ -1,13 +1,23 @@
 import { b, is, isIdentifierName, walk, walkAsync } from 'yuku-ast'
 import {
+  Meaning,
+  QUALIFIER_MEANING,
+  type Dep,
+  type NamespaceMap,
+  type NamespaceMember,
+  type NamespaceScope,
+  type TypeParams,
+} from './types.ts'
+import {
+  getDeclarationBindings,
   getIdentifierIndex,
   getIdFromTSEntityName,
+  getRootIdentifier,
   isReferenceId,
   isThisExpression,
   overwriteNode,
   TSEntityNameToRuntime,
 } from './utils.ts'
-import type { Dep, NamespaceMap, TypeParams } from './types.ts'
 import type { TransformPluginContext } from 'rolldown'
 import type * as t from 'yuku-parser'
 
@@ -47,6 +57,96 @@ export function collectParams(node: t.Node): TypeParams {
   }))
 }
 
+function getDeclarationMeaning(node: t.Node): number {
+  switch (node.type) {
+    case 'TSTypeAliasDeclaration':
+    case 'TSInterfaceDeclaration':
+      return Meaning.Type
+    case 'VariableDeclaration':
+    case 'FunctionDeclaration':
+    case 'TSDeclareFunction':
+      return Meaning.Value
+    case 'ClassDeclaration':
+      return Meaning.Type | Meaning.Value
+    case 'TSModuleDeclaration':
+      return Meaning.Namespace | Meaning.Value
+    case 'TSEnumDeclaration':
+    case 'TSImportEqualsDeclaration':
+      return Meaning.Any
+    default:
+      return 0
+  }
+}
+
+function isNamespaceWithBody(
+  node: t.Node,
+): node is t.TSModuleDeclaration & { body: t.TSModuleBlock } {
+  return (
+    node.type === 'TSModuleDeclaration' &&
+    node.kind === 'namespace' &&
+    !!node.body
+  )
+}
+
+/**
+ * Collects the names declared directly in the body of a namespace. They are in
+ * scope for the whole body, where they shadow the names around the namespace.
+ */
+function collectNamespaceMembers(
+  node: t.Node,
+  params: TypeParams,
+): Map<string, NamespaceMember> {
+  const members = new Map<string, NamespaceMember>()
+  if (!isNamespaceWithBody(node)) return members
+
+  for (const [decl, meaning] of memberDeclarations(node.body)) {
+    for (const binding of getDeclarationBindings(decl)) {
+      const member = members.get(binding.name)
+      if (member) {
+        member.meaning |= meaning
+        member.bindings.push(binding)
+      } else {
+        members.set(binding.name, {
+          name: binding.name,
+          meaning,
+          bindings: [binding],
+          references: new Set(),
+        })
+      }
+    }
+  }
+
+  // A type parameter or a member of a nested namespace shadows the member
+  // again. Which of them a reference means is not tracked, so leave those
+  // names alone.
+  for (const { name } of params) {
+    members.delete(name)
+  }
+  walk(node, {
+    enter(child) {
+      if (child.type !== 'TSModuleBlock' || child === node.body) return
+      for (const [decl] of memberDeclarations(child)) {
+        for (const binding of getDeclarationBindings(decl)) {
+          members.delete(binding.name)
+        }
+      }
+    },
+  })
+
+  return members
+}
+
+function* memberDeclarations(
+  block: t.TSModuleBlock,
+): Generator<[decl: t.Node, meaning: number]> {
+  for (const stmt of block.body) {
+    const decl =
+      stmt.type === 'ExportNamedDeclaration' ? stmt.declaration : stmt
+    const meaning = decl ? getDeclarationMeaning(decl) : 0
+    if (decl && meaning) yield [decl, meaning]
+  }
+}
+
 export async function collectDependencies(
   context: TransformPluginContext,
   node: t.Node,
@@ -54,8 +154,11 @@ export async function collectDependencies(
   namespaceStmts: NamespaceMap,
   children: Set<t.Node>,
   identifierMap: Record<string, number>,
-): Promise<Dep[]> {
+  params: TypeParams,
+): Promise<{ deps: Dep[]; namespace?: NamespaceScope }> {
   const deps = new Set<Dep>()
+  const meanings = new Map<Dep, number>()
+  const members = collectNamespaceMembers(node, params)
   const seen = new Set<t.Node>()
   const preserveImportTypeCache = new Map<string, boolean>()
 
@@ -90,18 +193,18 @@ export async function collectDependencies(
       if (node.type === 'ExportNamedDeclaration') {
         for (const specifier of node.specifiers) {
           if (specifier.type === 'ExportSpecifier') {
-            addDependency(specifier.local)
+            addDependency(specifier.local, Meaning.Any)
           }
         }
       } else if (node.type === 'TSInterfaceDeclaration' && node.extends) {
         for (const heritage of node.extends || []) {
-          addDependency(heritage.expression)
+          addDependency(heritage.expression, Meaning.Type)
         }
       } else if (node.type === 'ClassDeclaration') {
-        if (node.superClass) addDependency(node.superClass)
+        if (node.superClass) addDependency(node.superClass, Meaning.Value)
         if (node.implements) {
           for (const implement of node.implements) {
-            addDependency(implement.expression)
+            addDependency(implement.expression, Meaning.Type)
           }
         }
       } else if (
@@ -116,26 +219,26 @@ export async function collectDependencies(
         ])
       ) {
         if (node.computed && isReferenceId(node.key)) {
-          addDependency(node.key)
+          addDependency(node.key, Meaning.Value)
         }
         if ('value' in node && isReferenceId(node.value)) {
-          addDependency(node.value)
+          addDependency(node.value, Meaning.Value)
         }
       } else {
         switch (node.type) {
           case 'TSTypeReference': {
-            addDependency(TSEntityNameToRuntime(node.typeName))
+            addDependency(TSEntityNameToRuntime(node.typeName), Meaning.Type)
             break
           }
           case 'TSQualifiedName': {
-            addDependency(getIdFromTSEntityName(node.left))
+            addDependency(getIdFromTSEntityName(node.left), QUALIFIER_MEANING)
             break
           }
           case 'TSTypeQuery': {
             if (seen.has(node.exprName)) return
             if (node.exprName.type === 'TSImportType') break
 
-            addDependency(TSEntityNameToRuntime(node.exprName))
+            addDependency(TSEntityNameToRuntime(node.exprName), Meaning.Value)
 
             break
           }
@@ -156,7 +259,7 @@ export async function collectDependencies(
               namespaceStmts,
               identifierMap,
             )
-            if (dep) addDependency(dep)
+            if (dep) addDependency(dep, Meaning.Type)
             break
           }
         }
@@ -168,11 +271,35 @@ export async function collectDependencies(
     },
   })
 
-  return Array.from(deps)
+  const result = Array.from(deps)
+  return {
+    deps: result,
+    namespace:
+      members.size && isNamespaceWithBody(node)
+        ? {
+            body: [...node.body.body],
+            members: Array.from(members.values()),
+            depMeanings: result.map((dep) => meanings.get(dep)!),
+          }
+        : undefined,
+  }
 
-  function addDependency(node: Dep) {
+  function addDependency(node: Dep, meaning: number) {
     if (isThisExpression(node) || isInferred(node)) return
+
+    const root = getRootIdentifier(node)
+    const member = root && members.get(root.name)
+    if (
+      member &&
+      member.meaning & (root === node ? meaning : QUALIFIER_MEANING)
+    ) {
+      // refers to a member of the namespace, not to anything around it
+      member.references.add(root)
+      return
+    }
+
     deps.add(node)
+    meanings.set(node, meaning)
   }
 }
 

--- a/src/fake-js/dependency.ts
+++ b/src/fake-js/dependency.ts
@@ -155,7 +155,12 @@ export async function collectDependencies(
   children: Set<t.Node>,
   identifierMap: Record<string, number>,
   params: TypeParams,
-): Promise<{ deps: Dep[]; namespace?: NamespaceScope }> {
+): Promise<{
+  deps: Dep[]
+  /** Bit set of `Meaning` for each dependency, what it has to refer to */
+  meanings: number[]
+  namespace?: NamespaceScope
+}> {
   const deps = new Set<Dep>()
   const meanings = new Map<Dep, number>()
   const members = collectNamespaceMembers(node, params)
@@ -274,12 +279,12 @@ export async function collectDependencies(
   const result = Array.from(deps)
   return {
     deps: result,
+    meanings: result.map((dep) => meanings.get(dep)!),
     namespace:
       members.size && isNamespaceWithBody(node)
         ? {
             body: [...node.body.body],
             members: Array.from(members.values()),
-            depMeanings: result.map((dep) => meanings.get(dep)!),
           }
         : undefined,
   }

--- a/src/fake-js/index.ts
+++ b/src/fake-js/index.ts
@@ -18,6 +18,7 @@ import {
 } from './exports.ts'
 import {
   patchImportExport,
+  patchNamespaceMembers,
   patchReExport,
   patchTsNamespace,
   rewriteImportExport,
@@ -259,13 +260,14 @@ export function createFakeJsPlugin({
 
       const params: TypeParams = collectParams(decl)
       const childrenSet = new Set<t.Node>()
-      const deps = await collectDependencies(
+      const { deps, namespace } = await collectDependencies(
         this,
         decl,
         id,
         namespaceStmts,
         childrenSet,
         identifierMap,
+        params,
       )
       const children = Array.from(childrenSet).filter((child) =>
         bindings.every((b) => child !== b),
@@ -281,6 +283,7 @@ export function createFakeJsPlugin({
         bindings,
         params,
         children,
+        namespace,
         exportType: isDefaultExport
           ? 'default'
           : isExportDecl
@@ -522,6 +525,14 @@ export function createFakeJsPlugin({
         } else {
           Object.assign(originalDep, transformedDep)
         }
+      }
+
+      if (declaration.namespace) {
+        patchNamespaceMembers(
+          declaration.decl as t.TSModuleDeclaration,
+          declaration.namespace,
+          transformedDeps,
+        )
       }
 
       const kind = exportPlan.inlineKinds.get(declarationId!)

--- a/src/fake-js/index.ts
+++ b/src/fake-js/index.ts
@@ -260,7 +260,7 @@ export function createFakeJsPlugin({
 
       const params: TypeParams = collectParams(decl)
       const childrenSet = new Set<t.Node>()
-      const { deps, namespace } = await collectDependencies(
+      const { deps, meanings, namespace } = await collectDependencies(
         this,
         decl,
         id,
@@ -280,6 +280,7 @@ export function createFakeJsPlugin({
       const declarationId = registerDeclaration({
         decl,
         deps,
+        depMeanings: meanings,
         bindings,
         params,
         children,
@@ -532,6 +533,7 @@ export function createFakeJsPlugin({
           declaration.decl as t.TSModuleDeclaration,
           declaration.namespace,
           transformedDeps,
+          declaration.depMeanings,
         )
       }
 

--- a/src/fake-js/patch.ts
+++ b/src/fake-js/patch.ts
@@ -193,12 +193,14 @@ function getExportAllNamespace(
  * }
  * ```
  *
- * `deps` are the dependencies of the declaration after bundling.
+ * `deps` are the dependencies of the declaration after bundling, `depMeanings`
+ * what each of them has to refer to.
  */
 export function patchNamespaceMembers(
   decl: t.TSModuleDeclaration,
   scope: NamespaceScope,
   deps: t.Node[],
+  depMeanings: number[],
 ): void {
   const block = decl.body!
 
@@ -216,7 +218,7 @@ export function patchNamespaceMembers(
       const root = getRootIdentifier(dep)
       if (root?.name !== member.name) return false
 
-      const meaning = root === dep ? scope.depMeanings[i] : QUALIFIER_MEANING
+      const meaning = root === dep ? depMeanings[i] : QUALIFIER_MEANING
       return !!(member.meaning & meaning)
     })
     if (!captures) continue

--- a/src/fake-js/patch.ts
+++ b/src/fake-js/patch.ts
@@ -1,7 +1,12 @@
-import { b, is, nameOf } from 'yuku-ast'
+import { b, is, nameOf, walk } from 'yuku-ast'
 import { filename_dts_to, RE_DTS } from '../filename.ts'
-import { isInfer } from './utils.ts'
-import type { ChunkExportPlan } from './types.ts'
+import {
+  QUALIFIER_MEANING,
+  type ChunkExportPlan,
+  type NamespaceMember,
+  type NamespaceScope,
+} from './types.ts'
+import { getDeclarationBindings, getRootIdentifier, isInfer } from './utils.ts'
 import type * as t from 'yuku-parser'
 
 /**
@@ -164,6 +169,177 @@ function getExportAllNamespace(
 
   const exports = node.declarations[0].init.arguments[0]
   return [source, exports] as const
+}
+
+/**
+ * A namespace body is a scope of its own. rolldown does not know about it, so
+ * it may rename a reference inside of the body to the name of a member of that
+ * very namespace, which then captures the reference:
+ *
+ * ```ts
+ * import { Foo as OuterFoo } from './foo'
+ * declare namespace N {
+ *   export type Foo = OuterFoo // bundled to `type Foo = Foo`
+ * }
+ * ```
+ *
+ * A captured member is renamed together with the references to it, and
+ * exported under its original name by a specifier:
+ *
+ * ```ts
+ * declare namespace N {
+ *   type Foo$1 = Foo
+ *   export { Foo$1 as Foo }
+ * }
+ * ```
+ *
+ * `deps` are the dependencies of the declaration after bundling.
+ */
+export function patchNamespaceMembers(
+  decl: t.TSModuleDeclaration,
+  scope: NamespaceScope,
+  deps: t.Node[],
+): void {
+  const block = decl.body!
+
+  // `renderChunk` may run again for the same declaration, start over
+  block.body = [...scope.body]
+  for (const member of scope.members) {
+    renameNamespaceMember(member, member.name)
+  }
+
+  const renamed = new Map<string /* new name */, string /* member name */>()
+  let usedNames: Set<string> | undefined
+
+  for (const member of scope.members) {
+    const captures = deps.some((dep, i) => {
+      const root = getRootIdentifier(dep)
+      if (root?.name !== member.name) return false
+
+      const meaning = root === dep ? scope.depMeanings[i] : QUALIFIER_MEANING
+      return !!(member.meaning & meaning)
+    })
+    if (!captures) continue
+
+    // The new name is only visible inside of the namespace, so it is enough to
+    // not collide with any name used in there.
+    usedNames ||= collectIdentifierNames(decl)
+    let index = 1
+    let name: string
+    do {
+      name = `${member.name}$${index++}`
+    } while (usedNames.has(name))
+    usedNames.add(name)
+
+    renameNamespaceMember(member, name)
+    renamed.set(name, member.name)
+  }
+
+  if (renamed.size) {
+    block.body = exportRenamedMembers(block.body, renamed)
+  }
+}
+
+function renameNamespaceMember(member: NamespaceMember, name: string): void {
+  for (const id of member.bindings) id.name = name
+  for (const id of member.references) id.name = name
+}
+
+function collectIdentifierNames(node: t.Node): Set<string> {
+  const names = new Set<string>()
+  walk(node, {
+    enter(node) {
+      if (node.type === 'Identifier') names.add(node.name)
+    },
+  })
+  return names
+}
+
+function isMemberDeclaration(node: t.Node): node is t.Declaration {
+  return node.type === 'TSDeclareFunction' || is.Declaration(node)
+}
+
+function exportRenamedMembers(
+  body: t.ProgramStatement[],
+  renamed: Map<string /* new name */, string /* member name */>,
+): t.ProgramStatement[] {
+  // An ambient namespace without any export declaration exports all of its
+  // members but the import aliases, with or without an `export` keyword.
+  const implicitExport = body.every(
+    (stmt) =>
+      !(
+        (stmt.type === 'ExportNamedDeclaration' && !stmt.declaration) ||
+        stmt.type === 'ExportAllDeclaration' ||
+        stmt.type === 'ExportDefaultDeclaration' ||
+        stmt.type === 'TSExportAssignment'
+      ),
+  )
+
+  const members = body.map((stmt) => {
+    const hasExportKeyword =
+      stmt.type === 'ExportNamedDeclaration' && !!stmt.declaration
+    const decl = hasExportKeyword ? stmt.declaration! : stmt
+    if (!isMemberDeclaration(decl)) return { stmt }
+
+    const names = getDeclarationBindings(decl).map((id) => id.name)
+    return {
+      stmt,
+      decl,
+      names,
+      hasExportKeyword,
+      exported:
+        hasExportKeyword ||
+        (implicitExport && decl.type !== 'TSImportEqualsDeclaration'),
+      renamed: names.some((name) => renamed.has(name)),
+    }
+  })
+
+  // a member nobody outside of the namespace can see only has to be renamed
+  if (members.every((member) => !member.renamed || !member.exported)) {
+    return body
+  }
+
+  const specifiers = new Map<string /* local */, t.ExportSpecifier>()
+  const result: t.ProgramStatement[] = members.map((member) => {
+    const { stmt, decl } = member
+    if (!decl) return stmt
+
+    if (!member.renamed) {
+      // the export declaration added below ends the implicit export
+      return member.exported && !member.hasExportKeyword
+        ? b.ExportNamedDeclaration({
+            declaration: decl,
+            specifiers: [],
+            source: null,
+            attributes: [],
+          })
+        : stmt
+    }
+
+    if (member.exported) {
+      for (const name of member.names) {
+        specifiers.set(
+          name,
+          b.ExportSpecifier({
+            local: b.Identifier({ name }),
+            exported: b.Identifier({ name: renamed.get(name) ?? name }),
+          }),
+        )
+      }
+    }
+    // drop the `export` keyword, but keep the comments in front of it
+    return member.hasExportKeyword ? { ...decl, comments: stmt.comments } : stmt
+  })
+
+  result.push(
+    b.ExportNamedDeclaration({
+      declaration: null,
+      specifiers: Array.from(specifiers.values()),
+      source: null,
+      attributes: [],
+    }),
+  )
+  return result
 }
 
 /**

--- a/src/fake-js/types.ts
+++ b/src/fake-js/types.ts
@@ -10,12 +10,49 @@ export type TypeParams = Array<{
   typeParams: t.Identifier[]
 }>
 
+/**
+ * The declaration spaces of TypeScript. A name can mean something different in
+ * each of them, e.g. `var Foo: Foo` declares a value and refers to a type.
+ */
+export const Meaning = {
+  Type: 1,
+  Value: 2,
+  Namespace: 4,
+  Any: 7,
+} as const
+
+/**
+ * `a` in `a.b` is a namespace, or a value in `typeof a.b`, but never a type
+ */
+export const QUALIFIER_MEANING: number = Meaning.Namespace | Meaning.Value
+
+/** A name declared directly in the body of a namespace */
+export interface NamespaceMember {
+  name: string
+  /** Bit set of `Meaning`, what the name means inside of the body */
+  meaning: number
+  /** The identifiers declaring the member */
+  bindings: t.Identifier[]
+  /** The identifiers inside of the body referring to the member */
+  references: Set<t.Identifier>
+}
+
+export interface NamespaceScope {
+  /** The statements of the body, as parsed */
+  body: t.ProgramStatement[]
+  members: NamespaceMember[]
+  /** Bit set of `Meaning` for each dependency of the declaration */
+  depMeanings: number[]
+}
+
 export interface DeclarationInfo {
   decl: t.Declaration
   bindings: t.Identifier[]
   params: TypeParams
   deps: Dep[]
   children: t.Node[]
+  /** The scope of a namespace declaring members, see `patchNamespaceMembers` */
+  namespace?: NamespaceScope
   /** How the declaration was exported in the source file, if it was */
   exportType?: InlineExportKind
   /** The comments attached to the declaration, as parsed */

--- a/src/fake-js/types.ts
+++ b/src/fake-js/types.ts
@@ -41,8 +41,6 @@ export interface NamespaceScope {
   /** The statements of the body, as parsed */
   body: t.ProgramStatement[]
   members: NamespaceMember[]
-  /** Bit set of `Meaning` for each dependency of the declaration */
-  depMeanings: number[]
 }
 
 export interface DeclarationInfo {
@@ -50,6 +48,8 @@ export interface DeclarationInfo {
   bindings: t.Identifier[]
   params: TypeParams
   deps: Dep[]
+  /** Bit set of `Meaning` for each dependency, what it has to refer to */
+  depMeanings: number[]
   children: t.Node[]
   /** The scope of a namespace declaring members, see `patchNamespaceMembers` */
   namespace?: NamespaceScope

--- a/src/fake-js/utils.ts
+++ b/src/fake-js/utils.ts
@@ -38,6 +38,36 @@ export function getIdFromTSEntityName(
   return getIdFromTSEntityName(node.left)
 }
 
+/**
+ * The left-most identifier of a reference, `a` for `a.b.c`
+ */
+export function getRootIdentifier(node: t.Node): t.Identifier | undefined {
+  if (node.type === 'Identifier') return node
+  if (node.type === 'MemberExpression') return getRootIdentifier(node.object)
+  if (node.type === 'TSQualifiedName') return getRootIdentifier(node.left)
+}
+
+/**
+ * The identifiers a declaration binds. Destructuring patterns are ignored.
+ */
+export function getDeclarationBindings(node: t.Node): t.Identifier[] {
+  if (node.type === 'VariableDeclaration') {
+    return node.declarations
+      .map((decl) => decl.id)
+      .filter((id): id is t.Identifier => id.type === 'Identifier')
+  }
+
+  if ('id' in node && node.id) {
+    const id =
+      node.id.type === 'TSQualifiedName'
+        ? getIdFromTSEntityName(node.id)
+        : node.id
+    if (id.type === 'Identifier') return [id]
+  }
+
+  return []
+}
+
 export function isReferenceId(
   node?: t.Node | null,
 ): node is t.Identifier | t.MemberExpression {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -418,6 +418,135 @@ export interface Test {
 //#endregion"
 `;
 
+exports[`namespace members > across chunks 1`] = `
+"// capture.d.ts
+import { RequestOptions, Timeout, t as options_d_exports } from "./options.js";
+import { Socket } from "external-net";
+//#region capture.d.ts
+export declare class Client {}
+export declare namespace Client {
+  /** reached through a renamed import of an external module */
+  type Socket$1 = Socket;
+  /** reached through a renamed import */
+  type Timeout$1 = Timeout;
+  /** reached through a namespace import */
+  type RequestOptions$1 = RequestOptions;
+  export import Page = options_d_exports.Page;
+  export type Retry = {
+    timeout: Timeout$1;
+  };
+  export { Socket$1 as Socket, Timeout$1 as Timeout, RequestOptions$1 as RequestOptions };
+}
+//#endregion
+// options.d.ts
+declare namespace options_d_exports {
+  export { Page, RequestOptions, Theme, Timeout };
+}
+export interface RequestOptions {
+  timeout?: number;
+}
+export type Timeout = number;
+export interface Theme {
+  color: string;
+}
+export declare class Page<Item> {
+  items: Item[];
+}
+//#endregion
+export { options_d_exports as t };"
+`;
+
+exports[`namespace members > implicitly exported members 1`] = `
+"// implicit-export.d.ts
+//#region tests/fixtures/namespace-members/dts/options.d.ts
+type Timeout = number;
+//#endregion
+//#region tests/fixtures/namespace-members/dts/implicit-export.d.ts
+export declare namespace Config {
+  type Timeout$1 = Timeout;
+  export interface Limits {
+    timeout: Timeout$1;
+  }
+  export const version: string;
+  import Alias = Config.Limits;
+  export { Timeout$1 as Timeout };
+}
+//#endregion"
+`;
+
+exports[`namespace members > keep a member of another meaning 1`] = `
+"// no-capture.d.ts
+//#region tests/fixtures/namespace-members/options.d.ts
+interface RequestOptions {
+  timeout?: number;
+}
+type Timeout = number;
+interface Theme {
+  color: string;
+}
+declare class Page<Item> {
+  items: Item[];
+}
+//#endregion
+//#region tests/fixtures/namespace-members/no-capture.d.ts
+export declare function Card(): void;
+export declare namespace Card {
+  var Theme: Theme;
+}
+//#endregion"
+`;
+
+exports[`namespace members > member not exported 1`] = `
+"// private-member.d.ts
+//#region tests/fixtures/namespace-members/dts/options.d.ts
+type Timeout = number;
+//#endregion
+//#region tests/fixtures/namespace-members/dts/private-member.d.ts
+export declare namespace Config {
+  type Timeout$1 = Timeout;
+  export interface Limits {
+    timeout: Timeout$1;
+  }
+  export {};
+}
+//#endregion"
+`;
+
+exports[`namespace members > rename a member capturing a reference 1`] = `
+"// capture.d.ts
+import { Socket } from "external-net";
+declare namespace options_d_exports {
+  export { Page, RequestOptions, Theme, Timeout };
+}
+interface RequestOptions {
+  timeout?: number;
+}
+type Timeout = number;
+interface Theme {
+  color: string;
+}
+declare class Page<Item> {
+  items: Item[];
+}
+//#endregion
+//#region tests/fixtures/namespace-members/capture.d.ts
+export declare class Client {}
+export declare namespace Client {
+  /** reached through a renamed import of an external module */
+  type Socket$1 = Socket;
+  /** reached through a renamed import */
+  type Timeout$1 = Timeout;
+  /** reached through a namespace import */
+  type RequestOptions$1 = RequestOptions;
+  export import Page = options_d_exports.Page;
+  export type Retry = {
+    timeout: Timeout$1;
+  };
+  export { Socket$1 as Socket, Timeout$1 as Timeout, RequestOptions$1 as RequestOptions };
+}
+//#endregion"
+`;
+
 exports[`re-export from lib > both 1`] = `
 "// a.d.ts
 export * from "stub-lib";

--- a/tests/fixtures/namespace-members/capture.ts
+++ b/tests/fixtures/namespace-members/capture.ts
@@ -1,0 +1,18 @@
+import * as Opts from './options'
+import type { Socket as NetSocket } from 'external-net'
+import type { Timeout as OptsTimeout } from './options'
+
+export class Client {}
+
+export declare namespace Client {
+  /** reached through a renamed import of an external module */
+  export type Socket = NetSocket
+  /** reached through a renamed import */
+  export type Timeout = OptsTimeout
+  /** reached through a namespace import */
+  export type RequestOptions = Opts.RequestOptions
+  export import Page = Opts.Page
+
+  // refers to the member above, and has to keep doing so
+  export type Retry = { timeout: Timeout }
+}

--- a/tests/fixtures/namespace-members/dts/implicit-export.d.ts
+++ b/tests/fixtures/namespace-members/dts/implicit-export.d.ts
@@ -1,0 +1,10 @@
+import { Timeout as OptsTimeout } from './options'
+
+export declare namespace Config {
+  type Timeout = OptsTimeout
+  interface Limits {
+    timeout: Timeout
+  }
+  const version: string
+  import Alias = Config.Limits
+}

--- a/tests/fixtures/namespace-members/dts/options.d.ts
+++ b/tests/fixtures/namespace-members/dts/options.d.ts
@@ -1,0 +1,1 @@
+export type Timeout = number

--- a/tests/fixtures/namespace-members/dts/private-member.d.ts
+++ b/tests/fixtures/namespace-members/dts/private-member.d.ts
@@ -1,0 +1,9 @@
+import { Timeout as OptsTimeout } from './options'
+
+export declare namespace Config {
+  type Timeout = OptsTimeout
+  export interface Limits {
+    timeout: Timeout
+  }
+  export {}
+}

--- a/tests/fixtures/namespace-members/no-capture.ts
+++ b/tests/fixtures/namespace-members/no-capture.ts
@@ -1,0 +1,6 @@
+import type { Theme } from './options'
+
+export declare function Card(): void
+export declare namespace Card {
+  var Theme: Theme
+}

--- a/tests/fixtures/namespace-members/options.ts
+++ b/tests/fixtures/namespace-members/options.ts
@@ -1,0 +1,10 @@
+export interface RequestOptions {
+  timeout?: number
+}
+export type Timeout = number
+export interface Theme {
+  color: string
+}
+export declare class Page<Item> {
+  items: Item[]
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -707,6 +707,53 @@ test('sub namespace', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+describe('namespace members', () => {
+  const root = path.resolve(dirname, 'fixtures/namespace-members')
+
+  test('rename a member capturing a reference', async () => {
+    const { snapshot } = await rolldownBuild(path.resolve(root, 'capture.ts'), [
+      dts({ emitDtsOnly: true }),
+    ])
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).not.toMatch(/type (\w+) = \1\b/)
+  })
+
+  test('across chunks', async () => {
+    const { snapshot } = await rolldownBuild(
+      ['capture.ts', 'options.ts'],
+      [dts({ emitDtsOnly: true })],
+      { cwd: root },
+    )
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).not.toMatch(/type (\w+) = \1\b/)
+  })
+
+  test('keep a member of another meaning', async () => {
+    const { snapshot } = await rolldownBuild(
+      path.resolve(root, 'no-capture.ts'),
+      [dts({ emitDtsOnly: true })],
+    )
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('var Theme: Theme;')
+  })
+
+  test('implicitly exported members', async () => {
+    const { snapshot } = await rolldownBuild(
+      path.resolve(root, 'dts/implicit-export.d.ts'),
+      [dts({ dtsInput: true, tsconfig: false })],
+    )
+    expect(snapshot).toMatchSnapshot()
+  })
+
+  test('member not exported', async () => {
+    const { snapshot } = await rolldownBuild(
+      path.resolve(root, 'dts/private-member.d.ts'),
+      [dts({ dtsInput: true, tsconfig: false })],
+    )
+    expect(snapshot).toMatchSnapshot()
+  })
+})
+
 test('deterministic namespace import index', async () => {
   const cwd = path.resolve(dirname, 'fixtures/import-type-multi')
   // Build multiple times to verify deterministic output

--- a/tests/rollup-plugin-dts/namespace-references/snapshot.d.ts
+++ b/tests/rollup-plugin-dts/namespace-references/snapshot.d.ts
@@ -1,9 +1,5 @@
 // index.d.ts
 //#region tests/rollup-plugin-dts/namespace-references/ns.d.ts
-interface Shadowed1 {}
-interface Shadowed2 {}
-interface Shadowed3 {}
-interface Shadowed4 {}
 interface Referenced1 {}
 interface Referenced2 {}
 export declare namespace ns {


### PR DESCRIPTION
A member of a `declare namespace` named like the declaration it aliases, e.g. `export type Foo = OuterFoo`, was bundled to `type Foo = Foo` once rolldown renamed the reference. The member is now renamed and exported under its original name, and references to a member no longer count as dependencies on a same-named declaration around the namespace.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### AI usage

<!--
AI CONTRIBUTORS: You MUST complete this section truthfully and MUST NOT remove it.

If AI contributed to any part of this PR (including code, tests, documentation, commit
messages, or the PR description), select "AI was used" and disclose your setup in one
short line, such as "Codex + GPT 5.6 Sol Extra High" or "Claude Code + Opus 4.8 High".
Do not select "No AI was used" if AI assisted with this PR.

You MUST NOT check the human-review checkbox yourself. Leave it unchecked for the human
contributor, who may check it only after personally reviewing the AI-generated content.

Do not write a long explanation. Unless extra context is necessary for review, let the
code explain the implementation details and keep the PR body to a brief overview.

This project does not oppose the use of AI, but it does oppose irresponsible AI usage.

PRs containing AI-generated content without complete disclosure will not be reviewed
and will be closed immediately.
-->

- [ ] No AI was used in this PR.
- [x] AI was used: Claude Code; Claude Fable 5.1
  - [x] I have carefully reviewed the AI-generated content myself.

Claude authored the code of this PR. I have reviewed the fix and believe it to be correct. The fix includes detailed tests that demonstrate the broken behavior (as reported in #366); these tests fail without this PR’s changes, and produce correct results after applying this PR’s changes to fake-js. 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


Before this PR, a member of a `declare namespace` that has the same name as the declaration it aliases is bundled into a reference to itself, for example :
```ts
import type { Socket as NetSocket } from 'node:net';
export declare namespace Client {
  export type Socket = NetSocket;  // this gets emitted as `type Socket = Socket`
}
```
The same happens through a namespace import (`import * as Opts` with `export type RequestOptions = Opts.RequestOptions`) and with local modules.

The namespace body is a single opaque declaration in the fake JS, so rolldown would resolve the reference to its canonical name without realizing that the body declares a conflicting member of that same name. This PR solves it by tracking the direct members of a namespace:
- In `transform`, we record a reference that TypeScript resolves to a member **as a reference to that member**, instead of a dependency.
- In `renderChunk`, any member that conflicts with one of the bundled dependencies gets renamed, and exported under its original name, producing output like
  ```ts
  export declare namespace Client {
    type Socket$1 = Socket;
    export { Socket$1 as Socket };
  }
  ```

Since a conflict can only occur within the same declaration space (types, runtime variables, etc), code like `var Theme: Theme` is not a conflict; we consider this and leave this type of code alone so it prints the same as before.

One existing snapshot changes - `tests/rollup-plugin-dts/namespace-references` no longer keeps the four top-level `ShadowedN` interfaces alive; this was one of the recorded known diffs from rollup-plugin-dts for that fixture, and the output now agrees with that part


### Linked Issues

Closes rolldown/tsdown#366

### Additional context

- Only the direct members of a namespace are tracked. A name that a type parameter or a nested namespace declares again is left to the current behaviour, and `declare global` / `declare module '...'` are not touched.
- An ambient namespace without any export declaration exports all of its members implicitly, so adding the `export { ... }` specifier would stop exporting the others. They get an explicit `export` in that case, except import aliases, which are never exported implicitly. The `implicitly exported members` test covers this.
- The stored declaration is reset before each render, since `renderChunk` can run more than once for it.