### PR TITLE
fix: keep `typeof X` of a global value from being renamed alongside a same-named type

### DIFF
--- a/src/fake-js/README.md
+++ b/src/fake-js/README.md
@@ -106,6 +106,39 @@ what a reference asks for. Only the direct members of the namespace are tracked,
 and a name that a type parameter or a nested namespace declares again is left
 alone.
 
+## Types and values
+
+TypeScript keeps types, values and namespaces apart, JavaScript has a single
+namespace. A name can be a type in a module and a value in the global scope:
+
+```ts
+import type { Response } from './typed-response' // an interface
+export interface Options {
+  Response?: typeof Response // the global constructor
+}
+```
+
+In the fake-JS both are the same `Response` bound to the import, so rolldown
+renames the `typeof` along with the interface once that gets another name.
+
+`transform` records two things. For every dependency, what it needs: `typeof X`
+needs a value, `x: X` a type. And for every module, what each of its top-level
+names is: `interface Response` is only a type, `class Foo` a type and a value,
+an import whatever it points to, followed through re-exports as long as they
+stay inside the bundle.
+
+`renderChunk` compares the two whenever a dependency was renamed. `typeof
+Response` above needs a value, but the only `Response` in its module is an
+imported interface, so it cannot have meant the import. It meant the global, and
+gets back the name it was written with.
+
+If it is unclear what a name is, for example because it comes from an external
+module, it counts as possibly anything and the rename is kept. A reference is
+only reset when that is certain to be right.
+
+The dependency itself stays, so the declaration it was bound to is not
+tree-shaken because of this.
+
 ## Export shape
 
 A declaration written as `export declare const x` is emitted as
@@ -145,12 +178,12 @@ Smaller ones:
 
 ## Files
 
-| File                 | Scope                                                                                                                                                                                                                                                                                  |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index.ts`           | The plugin. `transform` turns a declaration file into fake JavaScript, `renderChunk` turns a bundled chunk back into declarations, and `declarationMap` connects the two. Also names the `.d.ts` chunks and drops the `.d.ts.map` files when sourcemaps are off.                       |
-| `exports.ts`         | Everything about the shape of the exports: what each module exports, collected during `transform`, and the `ChunkExportPlan` of a chunk — which names are type only, which declarations get their `export` keyword back, whether `export =` may be emitted.                            |
-| `patch.ts`           | Statement rewrites. `rewriteImportExport` prepares imports and exports for bundling, `patchImportExport`, `patchTsNamespace` and `patchReExport` undo that and rolldown's `__exportAll` / `__reExport` helpers afterwards, `patchNamespaceMembers` renames captured namespace members. |
-| `dependency.ts`      | Walks a declaration for what it references: type references, type parameters, the members of a namespace, and `import('...')` types, which are hoisted into real namespace imports so rolldown can resolve them.                                                                       |
-| `runtime-binding.ts` | The encoding above: the builder and the type guards that recognise it again in a chunk.                                                                                                                                                                                                |
-| `utils.ts`           | Small shared AST and comment helpers.                                                                                                                                                                                                                                                  |
-| `types.ts`           | The types shared across the files.                                                                                                                                                                                                                                                     |
+| File                 | Scope                                                                                                                                                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`           | The plugin. `transform` turns a declaration file into fake JavaScript, `renderChunk` turns a bundled chunk back into declarations, and `declarationMap` connects the two. Also names the `.d.ts` chunks and drops the `.d.ts.map` files when sourcemaps are off.                                        |
+| `exports.ts`         | Everything about the shape of the exports: what each module exports, collected during `transform` together with what its top-level names mean, and the `ChunkExportPlan` of a chunk — which names are type only, which declarations get their `export` keyword back, whether `export =` may be emitted. |
+| `patch.ts`           | Statement rewrites. `rewriteImportExport` prepares imports and exports for bundling, `patchImportExport`, `patchTsNamespace` and `patchReExport` undo that and rolldown's `__exportAll` / `__reExport` helpers afterwards, `patchNamespaceMembers` renames captured namespace members.                  |
+| `dependency.ts`      | Walks a declaration for what it references: type references, type parameters, the members of a namespace, and `import('...')` types, which are hoisted into real namespace imports so rolldown can resolve them.                                                                                        |
+| `runtime-binding.ts` | The encoding above: the builder and the type guards that recognise it again in a chunk.                                                                                                                                                                                                                 |
+| `utils.ts`           | Small shared AST and comment helpers.                                                                                                                                                                                                                                                                   |
+| `types.ts`           | The types shared across the files.                                                                                                                                                                                                                                                                      |

--- a/src/fake-js/README.md
+++ b/src/fake-js/README.md
@@ -68,6 +68,44 @@ var [binding, ...] = [declarationId, (typeParam, ...) => [dep, ...], ["child", .
 | children array  | One empty string literal per identifier inside the declaration, only used to carry source positions back for sourcemaps.                                                                                           |
 | `sideEffect()`  | Optional. A call to an unresolved global, so that a declaration nothing references — `declare module '...'`, `declare global` — is not tree-shaken away.                                                           |
 
+## Namespace members
+
+A whole `declare namespace N { ... }` is one declaration, so rolldown never
+sees the scope its body opens. Two things follow from that, both handled by the
+plugin itself.
+
+A reference in the body to a member of that namespace is not a dependency. It
+is recorded as a reference to the member instead, so that it neither keeps a
+declaration of the same name around the namespace alive nor follows it when
+rolldown renames it.
+
+And rolldown may rename a reference to something around the namespace to the
+name of a member, which then captures it:
+
+```ts
+import { Foo as OuterFoo } from './foo'
+export declare namespace N {
+  export type Foo = OuterFoo // after bundling: `type Foo = Foo`
+}
+```
+
+`renderChunk` looks for members captured like that, renames them together with
+the references to them, and exports them under their original name:
+
+```ts
+export declare namespace N {
+  type Foo$1 = Foo
+  export { Foo$1 as Foo }
+}
+```
+
+A name only collides within one declaration space of TypeScript: the value
+member of `var Theme: Theme` does not capture the type it is annotated with, so
+both steps compare what a member declares — a type, a value, a namespace — with
+what a reference asks for. Only the direct members of the namespace are tracked,
+and a name that a type parameter or a nested namespace declares again is left
+alone.
+
 ## Export shape
 
 A declaration written as `export declare const x` is emitted as
@@ -107,12 +145,12 @@ Smaller ones:
 
 ## Files
 
-| File                 | Scope                                                                                                                                                                                                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index.ts`           | The plugin. `transform` turns a declaration file into fake JavaScript, `renderChunk` turns a bundled chunk back into declarations, and `declarationMap` connects the two. Also names the `.d.ts` chunks and drops the `.d.ts.map` files when sourcemaps are off. |
-| `exports.ts`         | Everything about the shape of the exports: what each module exports, collected during `transform`, and the `ChunkExportPlan` of a chunk — which names are type only, which declarations get their `export` keyword back, whether `export =` may be emitted.      |
-| `patch.ts`           | Statement rewrites. `rewriteImportExport` prepares imports and exports for bundling, `patchImportExport`, `patchTsNamespace` and `patchReExport` undo that and rolldown's `__exportAll` / `__reExport` helpers afterwards.                                       |
-| `dependency.ts`      | Walks a declaration for what it references: type references, type parameters, and `import('...')` types, which are hoisted into real namespace imports so rolldown can resolve them.                                                                             |
-| `runtime-binding.ts` | The encoding above: the builder and the type guards that recognise it again in a chunk.                                                                                                                                                                          |
-| `utils.ts`           | Small shared AST and comment helpers.                                                                                                                                                                                                                            |
-| `types.ts`           | The types shared across the files.                                                                                                                                                                                                                               |
+| File                 | Scope                                                                                                                                                                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`           | The plugin. `transform` turns a declaration file into fake JavaScript, `renderChunk` turns a bundled chunk back into declarations, and `declarationMap` connects the two. Also names the `.d.ts` chunks and drops the `.d.ts.map` files when sourcemaps are off.                       |
+| `exports.ts`         | Everything about the shape of the exports: what each module exports, collected during `transform`, and the `ChunkExportPlan` of a chunk — which names are type only, which declarations get their `export` keyword back, whether `export =` may be emitted.                            |
+| `patch.ts`           | Statement rewrites. `rewriteImportExport` prepares imports and exports for bundling, `patchImportExport`, `patchTsNamespace` and `patchReExport` undo that and rolldown's `__exportAll` / `__reExport` helpers afterwards, `patchNamespaceMembers` renames captured namespace members. |
+| `dependency.ts`      | Walks a declaration for what it references: type references, type parameters, the members of a namespace, and `import('...')` types, which are hoisted into real namespace imports so rolldown can resolve them.                                                                       |
+| `runtime-binding.ts` | The encoding above: the builder and the type guards that recognise it again in a chunk.                                                                                                                                                                                                |
+| `utils.ts`           | Small shared AST and comment helpers.                                                                                                                                                                                                                                                  |
+| `types.ts`           | The types shared across the files.                                                                                                                                                                                                                                                     |

--- a/src/fake-js/dependency.ts
+++ b/src/fake-js/dependency.ts
@@ -3,6 +3,7 @@ import {
   Meaning,
   QUALIFIER_MEANING,
   type Dep,
+  type DepRoot,
   type NamespaceMap,
   type NamespaceMember,
   type NamespaceScope,
@@ -10,6 +11,7 @@ import {
 } from './types.ts'
 import {
   getDeclarationBindings,
+  getDeclarationMeaning,
   getIdentifierIndex,
   getIdFromTSEntityName,
   getRootIdentifier,
@@ -55,27 +57,6 @@ export function collectParams(node: t.Node): TypeParams {
     name,
     typeParams,
   }))
-}
-
-function getDeclarationMeaning(node: t.Node): number {
-  switch (node.type) {
-    case 'TSTypeAliasDeclaration':
-    case 'TSInterfaceDeclaration':
-      return Meaning.Type
-    case 'VariableDeclaration':
-    case 'FunctionDeclaration':
-    case 'TSDeclareFunction':
-      return Meaning.Value
-    case 'ClassDeclaration':
-      return Meaning.Type | Meaning.Value
-    case 'TSModuleDeclaration':
-      return Meaning.Namespace | Meaning.Value
-    case 'TSEnumDeclaration':
-    case 'TSImportEqualsDeclaration':
-      return Meaning.Any
-    default:
-      return 0
-  }
 }
 
 function isNamespaceWithBody(
@@ -159,10 +140,13 @@ export async function collectDependencies(
   deps: Dep[]
   /** Bit set of `Meaning` for each dependency, what it has to refer to */
   meanings: number[]
+  /** The left-most identifier of each dependency, as written */
+  roots: Array<DepRoot | undefined>
   namespace?: NamespaceScope
 }> {
   const deps = new Set<Dep>()
   const meanings = new Map<Dep, number>()
+  const roots = new Map<Dep, DepRoot>()
   const members = collectNamespaceMembers(node, params)
   const seen = new Set<t.Node>()
   const preserveImportTypeCache = new Map<string, boolean>()
@@ -280,6 +264,7 @@ export async function collectDependencies(
   return {
     deps: result,
     meanings: result.map((dep) => meanings.get(dep)!),
+    roots: result.map((dep) => roots.get(dep)),
     namespace:
       members.size && isNamespaceWithBody(node)
         ? {
@@ -293,11 +278,9 @@ export async function collectDependencies(
     if (isThisExpression(node) || isInferred(node)) return
 
     const root = getRootIdentifier(node)
+    const rootMeaning = root === node ? meaning : QUALIFIER_MEANING
     const member = root && members.get(root.name)
-    if (
-      member &&
-      member.meaning & (root === node ? meaning : QUALIFIER_MEANING)
-    ) {
+    if (member && member.meaning & rootMeaning) {
       // refers to a member of the namespace, not to anything around it
       member.references.add(root)
       return
@@ -305,6 +288,7 @@ export async function collectDependencies(
 
     deps.add(node)
     meanings.set(node, meaning)
+    if (root) roots.set(node, { name: root.name, meaning: rootMeaning })
   }
 }
 

--- a/src/fake-js/dependency.ts
+++ b/src/fake-js/dependency.ts
@@ -1,13 +1,23 @@
 import { b, is, isIdentifierName, walk, walkAsync } from 'yuku-ast'
 import {
+  Meaning,
+  QUALIFIER_MEANING,
+  type Dep,
+  type NamespaceMap,
+  type NamespaceMember,
+  type NamespaceScope,
+  type TypeParams,
+} from './types.ts'
+import {
+  getDeclarationBindings,
   getIdentifierIndex,
   getIdFromTSEntityName,
+  getRootIdentifier,
   isReferenceId,
   isThisExpression,
   overwriteNode,
   TSEntityNameToRuntime,
 } from './utils.ts'
-import type { Dep, NamespaceMap, TypeParams } from './types.ts'
 import type { TransformPluginContext } from 'rolldown'
 import type * as t from 'yuku-parser'
 
@@ -47,6 +57,96 @@ export function collectParams(node: t.Node): TypeParams {
   }))
 }
 
+function getDeclarationMeaning(node: t.Node): number {
+  switch (node.type) {
+    case 'TSTypeAliasDeclaration':
+    case 'TSInterfaceDeclaration':
+      return Meaning.Type
+    case 'VariableDeclaration':
+    case 'FunctionDeclaration':
+    case 'TSDeclareFunction':
+      return Meaning.Value
+    case 'ClassDeclaration':
+      return Meaning.Type | Meaning.Value
+    case 'TSModuleDeclaration':
+      return Meaning.Namespace | Meaning.Value
+    case 'TSEnumDeclaration':
+    case 'TSImportEqualsDeclaration':
+      return Meaning.Any
+    default:
+      return 0
+  }
+}
+
+function isNamespaceWithBody(
+  node: t.Node,
+): node is t.TSModuleDeclaration & { body: t.TSModuleBlock } {
+  return (
+    node.type === 'TSModuleDeclaration' &&
+    node.kind === 'namespace' &&
+    !!node.body
+  )
+}
+
+/**
+ * Collects the names declared directly in the body of a namespace. They are in
+ * scope for the whole body, where they shadow the names around the namespace.
+ */
+function collectNamespaceMembers(
+  node: t.Node,
+  params: TypeParams,
+): Map<string, NamespaceMember> {
+  const members = new Map<string, NamespaceMember>()
+  if (!isNamespaceWithBody(node)) return members
+
+  for (const [decl, meaning] of memberDeclarations(node.body)) {
+    for (const binding of getDeclarationBindings(decl)) {
+      const member = members.get(binding.name)
+      if (member) {
+        member.meaning |= meaning
+        member.bindings.push(binding)
+      } else {
+        members.set(binding.name, {
+          name: binding.name,
+          meaning,
+          bindings: [binding],
+          references: new Set(),
+        })
+      }
+    }
+  }
+
+  // A type parameter or a member of a nested namespace shadows the member
+  // again. Which of them a reference means is not tracked, so leave those
+  // names alone.
+  for (const { name } of params) {
+    members.delete(name)
+  }
+  walk(node, {
+    enter(child) {
+      if (child.type !== 'TSModuleBlock' || child === node.body) return
+      for (const [decl] of memberDeclarations(child)) {
+        for (const binding of getDeclarationBindings(decl)) {
+          members.delete(binding.name)
+        }
+      }
+    },
+  })
+
+  return members
+}
+
+function* memberDeclarations(
+  block: t.TSModuleBlock,
+): Generator<[decl: t.Node, meaning: number]> {
+  for (const stmt of block.body) {
+    const decl =
+      stmt.type === 'ExportNamedDeclaration' ? stmt.declaration : stmt
+    const meaning = decl ? getDeclarationMeaning(decl) : 0
+    if (decl && meaning) yield [decl, meaning]
+  }
+}
+
 export async function collectDependencies(
   context: TransformPluginContext,
   node: t.Node,
@@ -54,8 +154,11 @@ export async function collectDependencies(
   namespaceStmts: NamespaceMap,
   children: Set<t.Node>,
   identifierMap: Record<string, number>,
-): Promise<Dep[]> {
+  params: TypeParams,
+): Promise<{ deps: Dep[]; namespace?: NamespaceScope }> {
   const deps = new Set<Dep>()
+  const meanings = new Map<Dep, number>()
+  const members = collectNamespaceMembers(node, params)
   const seen = new Set<t.Node>()
   const preserveImportTypeCache = new Map<string, boolean>()
 
@@ -90,18 +193,18 @@ export async function collectDependencies(
       if (node.type === 'ExportNamedDeclaration') {
         for (const specifier of node.specifiers) {
           if (specifier.type === 'ExportSpecifier') {
-            addDependency(specifier.local)
+            addDependency(specifier.local, Meaning.Any)
           }
         }
       } else if (node.type === 'TSInterfaceDeclaration' && node.extends) {
         for (const heritage of node.extends || []) {
-          addDependency(heritage.expression)
+          addDependency(heritage.expression, Meaning.Type)
         }
       } else if (node.type === 'ClassDeclaration') {
-        if (node.superClass) addDependency(node.superClass)
+        if (node.superClass) addDependency(node.superClass, Meaning.Value)
         if (node.implements) {
           for (const implement of node.implements) {
-            addDependency(implement.expression)
+            addDependency(implement.expression, Meaning.Type)
           }
         }
       } else if (
@@ -116,26 +219,26 @@ export async function collectDependencies(
         ])
       ) {
         if (node.computed && isReferenceId(node.key)) {
-          addDependency(node.key)
+          addDependency(node.key, Meaning.Value)
         }
         if ('value' in node && isReferenceId(node.value)) {
-          addDependency(node.value)
+          addDependency(node.value, Meaning.Value)
         }
       } else {
         switch (node.type) {
           case 'TSTypeReference': {
-            addDependency(TSEntityNameToRuntime(node.typeName))
+            addDependency(TSEntityNameToRuntime(node.typeName), Meaning.Type)
             break
           }
           case 'TSQualifiedName': {
-            addDependency(getIdFromTSEntityName(node.left))
+            addDependency(getIdFromTSEntityName(node.left), QUALIFIER_MEANING)
             break
           }
           case 'TSTypeQuery': {
             if (seen.has(node.exprName)) return
             if (node.exprName.type === 'TSImportType') break
 
-            addDependency(TSEntityNameToRuntime(node.exprName))
+            addDependency(TSEntityNameToRuntime(node.exprName), Meaning.Value)
 
             break
           }
@@ -156,7 +259,7 @@ export async function collectDependencies(
               namespaceStmts,
               identifierMap,
             )
-            if (dep) addDependency(dep)
+            if (dep) addDependency(dep, Meaning.Type)
             break
           }
         }
@@ -168,11 +271,35 @@ export async function collectDependencies(
     },
   })
 
-  return Array.from(deps)
+  const result = Array.from(deps)
+  return {
+    deps: result,
+    namespace:
+      members.size && isNamespaceWithBody(node)
+        ? {
+            body: [...node.body.body],
+            members: Array.from(members.values()),
+            depMeanings: result.map((dep) => meanings.get(dep)!),
+          }
+        : undefined,
+  }
 
-  function addDependency(node: Dep) {
+  function addDependency(node: Dep, meaning: number) {
     if (isThisExpression(node) || isInferred(node)) return
+
+    const root = getRootIdentifier(node)
+    const member = root && members.get(root.name)
+    if (
+      member &&
+      member.meaning & (root === node ? meaning : QUALIFIER_MEANING)
+    ) {
+      // refers to a member of the namespace, not to anything around it
+      member.references.add(root)
+      return
+    }
+
     deps.add(node)
+    meanings.set(node, meaning)
   }
 }
 

--- a/src/fake-js/dependency.ts
+++ b/src/fake-js/dependency.ts
@@ -155,7 +155,12 @@ export async function collectDependencies(
   children: Set<t.Node>,
   identifierMap: Record<string, number>,
   params: TypeParams,
-): Promise<{ deps: Dep[]; namespace?: NamespaceScope }> {
+): Promise<{
+  deps: Dep[]
+  /** Bit set of `Meaning` for each dependency, what it has to refer to */
+  meanings: number[]
+  namespace?: NamespaceScope
+}> {
   const deps = new Set<Dep>()
   const meanings = new Map<Dep, number>()
   const members = collectNamespaceMembers(node, params)
@@ -274,12 +279,12 @@ export async function collectDependencies(
   const result = Array.from(deps)
   return {
     deps: result,
+    meanings: result.map((dep) => meanings.get(dep)!),
     namespace:
       members.size && isNamespaceWithBody(node)
         ? {
             body: [...node.body.body],
             members: Array.from(members.values()),
-            depMeanings: result.map((dep) => meanings.get(dep)!),
           }
         : undefined,
   }

--- a/src/fake-js/exports.ts
+++ b/src/fake-js/exports.ts
@@ -1,12 +1,14 @@
 import { b, is, nameOf } from 'yuku-ast'
 import { isRuntimeBindingVariableDeclaration } from './runtime-binding.ts'
-import { getIdFromTSEntityName } from './utils.ts'
-import type {
-  ChunkExportPlan,
-  DeclarationInfo,
-  InlineExportKind,
-  ModuleExports,
+import {
+  Meaning,
+  QUALIFIER_MEANING,
+  type ChunkExportPlan,
+  type DeclarationInfo,
+  type InlineExportKind,
+  type ModuleExports,
 } from './types.ts'
+import { getDeclarationMeaning, getIdFromTSEntityName } from './utils.ts'
 import type { RenderedChunk, TransformPluginContext } from 'rolldown'
 import type * as t from 'yuku-parser'
 
@@ -22,10 +24,14 @@ export async function collectModuleExports(
     exports: new Map(),
     reExports: [],
     exportAlls: [],
+    declared: new Map(),
+    imports: new Map(),
+    exportLocals: new Map(),
   }
 
   for (const node of nodes) {
     collectTypeOnlyLocals(node, info.typeOnlyLocals)
+    await collectBindings(context, node, id, info)
   }
 
   for (const node of nodes) {
@@ -48,6 +54,45 @@ function collectTypeOnlyLocals(
     ) {
       typeOnlyLocals.add(specifier.local.name)
     }
+  }
+}
+
+/**
+ * Collects what the top level of the module binds: the declarations with what
+ * they mean, and the imports with where they come from.
+ */
+async function collectBindings(
+  context: TransformPluginContext,
+  node: t.ProgramStatement,
+  id: string,
+  info: ModuleExports,
+): Promise<void> {
+  if (node.type === 'ImportDeclaration') {
+    const source = await resolveExportSource(context, node.source, id)
+    for (const specifier of node.specifiers) {
+      info.imports.set(specifier.local.name, {
+        source,
+        imported:
+          specifier.type === 'ImportSpecifier'
+            ? nameOf(specifier.imported)!
+            : specifier.type === 'ImportDefaultSpecifier'
+              ? 'default'
+              : '*',
+      })
+    }
+    return
+  }
+
+  const decl =
+    node.type === 'ExportNamedDeclaration' ||
+    node.type === 'ExportDefaultDeclaration'
+      ? node.declaration
+      : node
+  const meaning = decl ? getDeclarationMeaning(decl) : 0
+  if (!decl || !meaning) return
+
+  for (const name of collectDeclarationNames(decl)) {
+    info.declared.set(name, (info.declared.get(name) || 0) | meaning)
   }
 }
 
@@ -116,6 +161,7 @@ async function collectExportInfo(
     if (node.declaration) {
       for (const name of collectDeclarationNames(node.declaration)) {
         info.exports.set(name, false)
+        info.exportLocals.set(name, name)
       }
       return
     }
@@ -130,6 +176,7 @@ async function collectExportInfo(
         info.reExports.push({ source, local, exported, typeOnly })
       } else {
         info.exports.set(exported, typeOnly || info.typeOnlyLocals.has(local))
+        if (!node.source) info.exportLocals.set(exported, local)
       }
     }
     return
@@ -137,6 +184,11 @@ async function collectExportInfo(
 
   if (node.type === 'ExportDefaultDeclaration') {
     info.exports.set('default', false)
+    const [local] =
+      node.declaration.type === 'Identifier'
+        ? [node.declaration.name]
+        : collectDeclarationNames(node.declaration)
+    if (local) info.exportLocals.set('default', local)
     return
   }
 
@@ -165,6 +217,101 @@ async function resolveExportSource(
   if (!resolved || resolved.external) return
 
   return resolved.id
+}
+
+/**
+ * What a name means at the top level of a module, a bit set of `Meaning`.
+ * Follows imports to what they import, as far as that is part of the bundle;
+ * anything that cannot be told means `Meaning.Any`. Returns `undefined` if the
+ * module does not bind the name at all.
+ */
+export function resolveBindingMeaning(
+  moduleExportsMap: Map<string, ModuleExports>,
+  id: string,
+  name: string,
+  seen: Set<string> = new Set(),
+): number | undefined {
+  const info = moduleExportsMap.get(id)
+  if (!info) return Meaning.Any
+
+  const declared = info.declared.get(name)
+  const binding = info.imports.get(name)
+  if (!binding) return declared
+
+  let imported: number
+  if (binding.imported === '*') {
+    imported = QUALIFIER_MEANING
+  } else if (binding.source) {
+    imported =
+      resolveExportMeaning(
+        moduleExportsMap,
+        binding.source,
+        binding.imported,
+        seen,
+      ) ?? Meaning.Any
+  } else {
+    imported = Meaning.Any
+  }
+  return (declared || 0) | imported
+}
+
+/**
+ * What an export of a module means. Returns `undefined` if the module does not
+ * export the name.
+ */
+function resolveExportMeaning(
+  moduleExportsMap: Map<string, ModuleExports>,
+  id: string,
+  name: string,
+  seen: Set<string>,
+): number | undefined {
+  const info = moduleExportsMap.get(id)
+  if (!info) return Meaning.Any
+
+  const key = `${id}\0${name}`
+  if (seen.has(key)) return Meaning.Any
+  seen.add(key)
+
+  const local = info.exportLocals.get(name)
+  if (local !== undefined) {
+    return (
+      resolveBindingMeaning(moduleExportsMap, id, local, seen) ?? Meaning.Any
+    )
+  }
+
+  const reExport = info.reExports.find(({ exported }) => exported === name)
+  if (reExport) {
+    if (!reExport.source) return Meaning.Any
+    return (
+      resolveExportMeaning(
+        moduleExportsMap,
+        reExport.source,
+        reExport.local,
+        seen,
+      ) ?? Meaning.Any
+    )
+  }
+
+  // e.g. `export * as ns from '...'`
+  if (info.exports.has(name)) return Meaning.Any
+
+  if (name === 'default') return
+  let external = false
+  for (const exportAll of info.exportAlls) {
+    if (!exportAll.source) {
+      external = true
+      continue
+    }
+    const meaning = resolveExportMeaning(
+      moduleExportsMap,
+      exportAll.source,
+      name,
+      seen,
+    )
+    if (meaning !== undefined) return meaning
+  }
+  // an `export *` of an external module may export anything
+  if (external) return Meaning.Any
 }
 
 // #endregion

--- a/src/fake-js/index.ts
+++ b/src/fake-js/index.ts
@@ -18,6 +18,7 @@ import {
 } from './exports.ts'
 import {
   patchImportExport,
+  patchNamespaceMembers,
   patchReExport,
   patchTsNamespace,
   rewriteImportExport,
@@ -259,13 +260,14 @@ export function createFakeJsPlugin({
 
       const params: TypeParams = collectParams(decl)
       const childrenSet = new Set<t.Node>()
-      const deps = await collectDependencies(
+      const { deps, namespace } = await collectDependencies(
         this,
         decl,
         id,
         namespaceStmts,
         childrenSet,
         identifierMap,
+        params,
       )
       const children = Array.from(childrenSet).filter((child) =>
         bindings.every((b) => child !== b),
@@ -281,6 +283,7 @@ export function createFakeJsPlugin({
         bindings,
         params,
         children,
+        namespace,
         exportType: isDefaultExport
           ? 'default'
           : isExportDecl
@@ -522,6 +525,14 @@ export function createFakeJsPlugin({
         } else {
           Object.assign(originalDep, transformedDep)
         }
+      }
+
+      if (declaration.namespace) {
+        patchNamespaceMembers(
+          declaration.decl as t.TSModuleDeclaration,
+          declaration.namespace,
+          transformedDeps,
+        )
       }
 
       const kind = exportPlan.inlineKinds.get(declarationId!)

--- a/src/fake-js/index.ts
+++ b/src/fake-js/index.ts
@@ -260,7 +260,7 @@ export function createFakeJsPlugin({
 
       const params: TypeParams = collectParams(decl)
       const childrenSet = new Set<t.Node>()
-      const { deps, namespace } = await collectDependencies(
+      const { deps, meanings, namespace } = await collectDependencies(
         this,
         decl,
         id,
@@ -280,6 +280,7 @@ export function createFakeJsPlugin({
       const declarationId = registerDeclaration({
         decl,
         deps,
+        depMeanings: meanings,
         bindings,
         params,
         children,
@@ -532,6 +533,7 @@ export function createFakeJsPlugin({
           declaration.decl as t.TSModuleDeclaration,
           declaration.namespace,
           transformedDeps,
+          declaration.depMeanings,
         )
       }
 

--- a/src/fake-js/index.ts
+++ b/src/fake-js/index.ts
@@ -15,6 +15,7 @@ import {
   collectModuleExports,
   inlineExportDeclaration,
   planChunkExports,
+  resolveBindingMeaning,
 } from './exports.ts'
 import {
   patchImportExport,
@@ -31,6 +32,7 @@ import {
   collectReferenceDirectives,
   getIdentifierIndex,
   getIdFromTSEntityName,
+  getRootIdentifier,
   inheritNodeComments,
   isCjsDtsInputSyntax,
   isHelperImport,
@@ -260,7 +262,7 @@ export function createFakeJsPlugin({
 
       const params: TypeParams = collectParams(decl)
       const childrenSet = new Set<t.Node>()
-      const { deps, meanings, namespace } = await collectDependencies(
+      const { deps, meanings, roots, namespace } = await collectDependencies(
         this,
         decl,
         id,
@@ -281,9 +283,11 @@ export function createFakeJsPlugin({
         decl,
         deps,
         depMeanings: meanings,
+        depRoots: roots,
         bindings,
         params,
         children,
+        moduleId: id,
         namespace,
         exportType: isDefaultExport
           ? 'default'
@@ -521,6 +525,8 @@ export function createFakeJsPlugin({
           transformedDep.name = '__Infer'
         }
 
+        keepGlobalReference(declaration, i, transformedDep)
+
         if (originalDep.replace) {
           originalDep.replace(transformedDep)
         } else {
@@ -640,6 +646,47 @@ export function createFakeJsPlugin({
       // pragma it appends by a blank line
       code: result.code.trimEnd(),
       map: (result.map ?? null) as SourceMapInput | null,
+    }
+  }
+
+  /**
+   * Undoes a rename rolldown should not have made.
+   *
+   * TypeScript keeps types and values apart, JavaScript does not. Next to
+   * `import type { Response } from './response'`, where `Response` is an
+   * interface, `typeof Response` needs a value, so it means the global
+   * constructor. In the fake-JS it is bound to the import all the same, and
+   * gets renamed together with the interface.
+   *
+   * So for a renamed reference, compare what it needs with what that name is in
+   * its module. If the name cannot be that, e.g. a value is needed and it is
+   * only a type, the reference meant the global and gets its name back. If it
+   * is unclear what the name is, the rename is kept.
+   */
+  function keepGlobalReference(
+    declaration: DeclarationInfo,
+    index: number,
+    transformedDep: t.Node,
+  ) {
+    const root = declaration.depRoots[index]
+    const transformedRoot = getRootIdentifier(transformedDep)
+    if (
+      !root ||
+      !transformedRoot ||
+      transformedRoot.name === root.name ||
+      // bound by the deps function, not by the module
+      declaration.params.some((param) => param.name === root.name)
+    ) {
+      return
+    }
+
+    const meaning = resolveBindingMeaning(
+      moduleExportsMap,
+      declaration.moduleId,
+      root.name,
+    )
+    if (meaning !== undefined && !(meaning & root.meaning)) {
+      transformedRoot.name = root.name
     }
   }
 

--- a/src/fake-js/patch.ts
+++ b/src/fake-js/patch.ts
@@ -193,12 +193,14 @@ function getExportAllNamespace(
  * }
  * ```
  *
- * `deps` are the dependencies of the declaration after bundling.
+ * `deps` are the dependencies of the declaration after bundling, `depMeanings`
+ * what each of them has to refer to.
  */
 export function patchNamespaceMembers(
   decl: t.TSModuleDeclaration,
   scope: NamespaceScope,
   deps: t.Node[],
+  depMeanings: number[],
 ): void {
   const block = decl.body!
 
@@ -216,7 +218,7 @@ export function patchNamespaceMembers(
       const root = getRootIdentifier(dep)
       if (root?.name !== member.name) return false
 
-      const meaning = root === dep ? scope.depMeanings[i] : QUALIFIER_MEANING
+      const meaning = root === dep ? depMeanings[i] : QUALIFIER_MEANING
       return !!(member.meaning & meaning)
     })
     if (!captures) continue

--- a/src/fake-js/patch.ts
+++ b/src/fake-js/patch.ts
@@ -1,7 +1,12 @@
-import { b, is, nameOf } from 'yuku-ast'
+import { b, is, nameOf, walk } from 'yuku-ast'
 import { filename_dts_to, RE_DTS } from '../filename.ts'
-import { isInfer } from './utils.ts'
-import type { ChunkExportPlan } from './types.ts'
+import {
+  QUALIFIER_MEANING,
+  type ChunkExportPlan,
+  type NamespaceMember,
+  type NamespaceScope,
+} from './types.ts'
+import { getDeclarationBindings, getRootIdentifier, isInfer } from './utils.ts'
 import type * as t from 'yuku-parser'
 
 /**
@@ -164,6 +169,177 @@ function getExportAllNamespace(
 
   const exports = node.declarations[0].init.arguments[0]
   return [source, exports] as const
+}
+
+/**
+ * A namespace body is a scope of its own. rolldown does not know about it, so
+ * it may rename a reference inside of the body to the name of a member of that
+ * very namespace, which then captures the reference:
+ *
+ * ```ts
+ * import { Foo as OuterFoo } from './foo'
+ * declare namespace N {
+ *   export type Foo = OuterFoo // bundled to `type Foo = Foo`
+ * }
+ * ```
+ *
+ * A captured member is renamed together with the references to it, and
+ * exported under its original name by a specifier:
+ *
+ * ```ts
+ * declare namespace N {
+ *   type Foo$1 = Foo
+ *   export { Foo$1 as Foo }
+ * }
+ * ```
+ *
+ * `deps` are the dependencies of the declaration after bundling.
+ */
+export function patchNamespaceMembers(
+  decl: t.TSModuleDeclaration,
+  scope: NamespaceScope,
+  deps: t.Node[],
+): void {
+  const block = decl.body!
+
+  // `renderChunk` may run again for the same declaration, start over
+  block.body = [...scope.body]
+  for (const member of scope.members) {
+    renameNamespaceMember(member, member.name)
+  }
+
+  const renamed = new Map<string /* new name */, string /* member name */>()
+  let usedNames: Set<string> | undefined
+
+  for (const member of scope.members) {
+    const captures = deps.some((dep, i) => {
+      const root = getRootIdentifier(dep)
+      if (root?.name !== member.name) return false
+
+      const meaning = root === dep ? scope.depMeanings[i] : QUALIFIER_MEANING
+      return !!(member.meaning & meaning)
+    })
+    if (!captures) continue
+
+    // The new name is only visible inside of the namespace, so it is enough to
+    // not collide with any name used in there.
+    usedNames ||= collectIdentifierNames(decl)
+    let index = 1
+    let name: string
+    do {
+      name = `${member.name}$${index++}`
+    } while (usedNames.has(name))
+    usedNames.add(name)
+
+    renameNamespaceMember(member, name)
+    renamed.set(name, member.name)
+  }
+
+  if (renamed.size) {
+    block.body = exportRenamedMembers(block.body, renamed)
+  }
+}
+
+function renameNamespaceMember(member: NamespaceMember, name: string): void {
+  for (const id of member.bindings) id.name = name
+  for (const id of member.references) id.name = name
+}
+
+function collectIdentifierNames(node: t.Node): Set<string> {
+  const names = new Set<string>()
+  walk(node, {
+    enter(node) {
+      if (node.type === 'Identifier') names.add(node.name)
+    },
+  })
+  return names
+}
+
+function isMemberDeclaration(node: t.Node): node is t.Declaration {
+  return node.type === 'TSDeclareFunction' || is.Declaration(node)
+}
+
+function exportRenamedMembers(
+  body: t.ProgramStatement[],
+  renamed: Map<string /* new name */, string /* member name */>,
+): t.ProgramStatement[] {
+  // An ambient namespace without any export declaration exports all of its
+  // members but the import aliases, with or without an `export` keyword.
+  const implicitExport = body.every(
+    (stmt) =>
+      !(
+        (stmt.type === 'ExportNamedDeclaration' && !stmt.declaration) ||
+        stmt.type === 'ExportAllDeclaration' ||
+        stmt.type === 'ExportDefaultDeclaration' ||
+        stmt.type === 'TSExportAssignment'
+      ),
+  )
+
+  const members = body.map((stmt) => {
+    const hasExportKeyword =
+      stmt.type === 'ExportNamedDeclaration' && !!stmt.declaration
+    const decl = hasExportKeyword ? stmt.declaration! : stmt
+    if (!isMemberDeclaration(decl)) return { stmt }
+
+    const names = getDeclarationBindings(decl).map((id) => id.name)
+    return {
+      stmt,
+      decl,
+      names,
+      hasExportKeyword,
+      exported:
+        hasExportKeyword ||
+        (implicitExport && decl.type !== 'TSImportEqualsDeclaration'),
+      renamed: names.some((name) => renamed.has(name)),
+    }
+  })
+
+  // a member nobody outside of the namespace can see only has to be renamed
+  if (members.every((member) => !member.renamed || !member.exported)) {
+    return body
+  }
+
+  const specifiers = new Map<string /* local */, t.ExportSpecifier>()
+  const result: t.ProgramStatement[] = members.map((member) => {
+    const { stmt, decl } = member
+    if (!decl) return stmt
+
+    if (!member.renamed) {
+      // the export declaration added below ends the implicit export
+      return member.exported && !member.hasExportKeyword
+        ? b.ExportNamedDeclaration({
+            declaration: decl,
+            specifiers: [],
+            source: null,
+            attributes: [],
+          })
+        : stmt
+    }
+
+    if (member.exported) {
+      for (const name of member.names) {
+        specifiers.set(
+          name,
+          b.ExportSpecifier({
+            local: b.Identifier({ name }),
+            exported: b.Identifier({ name: renamed.get(name) ?? name }),
+          }),
+        )
+      }
+    }
+    // drop the `export` keyword, but keep the comments in front of it
+    return member.hasExportKeyword ? { ...decl, comments: stmt.comments } : stmt
+  })
+
+  result.push(
+    b.ExportNamedDeclaration({
+      declaration: null,
+      specifiers: Array.from(specifiers.values()),
+      source: null,
+      attributes: [],
+    }),
+  )
+  return result
 }
 
 /**

--- a/src/fake-js/types.ts
+++ b/src/fake-js/types.ts
@@ -43,6 +43,13 @@ export interface NamespaceScope {
   members: NamespaceMember[]
 }
 
+/** The left-most identifier of a dependency, `a` for `a.b.c`, as written */
+export interface DepRoot {
+  name: string
+  /** Bit set of `Meaning`, what the identifier has to refer to */
+  meaning: number
+}
+
 export interface DeclarationInfo {
   decl: t.Declaration
   bindings: t.Identifier[]
@@ -50,7 +57,10 @@ export interface DeclarationInfo {
   deps: Dep[]
   /** Bit set of `Meaning` for each dependency, what it has to refer to */
   depMeanings: number[]
+  depRoots: Array<DepRoot | undefined>
   children: t.Node[]
+  /** The module declaring it */
+  moduleId: string
   /** The scope of a namespace declaring members, see `patchNamespaceMembers` */
   namespace?: NamespaceScope
   /** How the declaration was exported in the source file, if it was */
@@ -64,6 +74,19 @@ export interface ModuleExports {
   exports: Map<string, boolean>
   reExports: ReExportInfo[]
   exportAlls: ExportAllInfo[]
+  /** Bit set of `Meaning` for each name declared at the top level */
+  declared: Map<string, number>
+  /** The imported bindings by their local name */
+  imports: Map<string, ImportBinding>
+  /** The local name of each export that is not a re-export */
+  exportLocals: Map<string /* exported */, string /* local */>
+}
+
+export interface ImportBinding {
+  /** The resolved id of the imported module, if it is part of the bundle */
+  source?: string
+  /** The imported name, `*` for a namespace import */
+  imported: string
 }
 
 export interface ReExportInfo {

--- a/src/fake-js/types.ts
+++ b/src/fake-js/types.ts
@@ -10,12 +10,49 @@ export type TypeParams = Array<{
   typeParams: t.Identifier[]
 }>
 
+/**
+ * The declaration spaces of TypeScript. A name can mean something different in
+ * each of them, e.g. `var Foo: Foo` declares a value and refers to a type.
+ */
+export const Meaning = {
+  Type: 1,
+  Value: 2,
+  Namespace: 4,
+  Any: 7,
+} as const
+
+/**
+ * `a` in `a.b` is a namespace, or a value in `typeof a.b`, but never a type
+ */
+export const QUALIFIER_MEANING: number = Meaning.Namespace | Meaning.Value
+
+/** A name declared directly in the body of a namespace */
+export interface NamespaceMember {
+  name: string
+  /** Bit set of `Meaning`, what the name means inside of the body */
+  meaning: number
+  /** The identifiers declaring the member */
+  bindings: t.Identifier[]
+  /** The identifiers inside of the body referring to the member */
+  references: Set<t.Identifier>
+}
+
+export interface NamespaceScope {
+  /** The statements of the body, as parsed */
+  body: t.ProgramStatement[]
+  members: NamespaceMember[]
+  /** Bit set of `Meaning` for each dependency of the declaration */
+  depMeanings: number[]
+}
+
 export interface DeclarationInfo {
   decl: t.Declaration
   bindings: t.Identifier[]
   params: TypeParams
   deps: Dep[]
   children: t.Node[]
+  /** The scope of a namespace declaring members, see `patchNamespaceMembers` */
+  namespace?: NamespaceScope
   /** How the declaration was exported in the source file, if it was */
   exportType?: InlineExportKind
   /** The comments attached to the declaration, as parsed */

--- a/src/fake-js/types.ts
+++ b/src/fake-js/types.ts
@@ -41,8 +41,6 @@ export interface NamespaceScope {
   /** The statements of the body, as parsed */
   body: t.ProgramStatement[]
   members: NamespaceMember[]
-  /** Bit set of `Meaning` for each dependency of the declaration */
-  depMeanings: number[]
 }
 
 export interface DeclarationInfo {
@@ -50,6 +48,8 @@ export interface DeclarationInfo {
   bindings: t.Identifier[]
   params: TypeParams
   deps: Dep[]
+  /** Bit set of `Meaning` for each dependency, what it has to refer to */
+  depMeanings: number[]
   children: t.Node[]
   /** The scope of a namespace declaring members, see `patchNamespaceMembers` */
   namespace?: NamespaceScope

--- a/src/fake-js/utils.ts
+++ b/src/fake-js/utils.ts
@@ -38,6 +38,36 @@ export function getIdFromTSEntityName(
   return getIdFromTSEntityName(node.left)
 }
 
+/**
+ * The left-most identifier of a reference, `a` for `a.b.c`
+ */
+export function getRootIdentifier(node: t.Node): t.Identifier | undefined {
+  if (node.type === 'Identifier') return node
+  if (node.type === 'MemberExpression') return getRootIdentifier(node.object)
+  if (node.type === 'TSQualifiedName') return getRootIdentifier(node.left)
+}
+
+/**
+ * The identifiers a declaration binds. Destructuring patterns are ignored.
+ */
+export function getDeclarationBindings(node: t.Node): t.Identifier[] {
+  if (node.type === 'VariableDeclaration') {
+    return node.declarations
+      .map((decl) => decl.id)
+      .filter((id): id is t.Identifier => id.type === 'Identifier')
+  }
+
+  if ('id' in node && node.id) {
+    const id =
+      node.id.type === 'TSQualifiedName'
+        ? getIdFromTSEntityName(node.id)
+        : node.id
+    if (id.type === 'Identifier') return [id]
+  }
+
+  return []
+}
+
 export function isReferenceId(
   node?: t.Node | null,
 ): node is t.Identifier | t.MemberExpression {

--- a/src/fake-js/utils.ts
+++ b/src/fake-js/utils.ts
@@ -1,4 +1,5 @@
 import { is } from 'yuku-ast'
+import { Meaning } from './types.ts'
 import type * as t from 'yuku-parser'
 
 export function isThisExpression(node: t.Node): boolean {
@@ -45,6 +46,30 @@ export function getRootIdentifier(node: t.Node): t.Identifier | undefined {
   if (node.type === 'Identifier') return node
   if (node.type === 'MemberExpression') return getRootIdentifier(node.object)
   if (node.type === 'TSQualifiedName') return getRootIdentifier(node.left)
+}
+
+/**
+ * What the names a declaration binds mean, a bit set of `Meaning`
+ */
+export function getDeclarationMeaning(node: t.Node): number {
+  switch (node.type) {
+    case 'TSTypeAliasDeclaration':
+    case 'TSInterfaceDeclaration':
+      return Meaning.Type
+    case 'VariableDeclaration':
+    case 'FunctionDeclaration':
+    case 'TSDeclareFunction':
+      return Meaning.Value
+    case 'ClassDeclaration':
+      return Meaning.Type | Meaning.Value
+    case 'TSModuleDeclaration':
+      return Meaning.Namespace | Meaning.Value
+    case 'TSEnumDeclaration':
+    case 'TSImportEqualsDeclaration':
+      return Meaning.Any
+    default:
+      return 0
+  }
 }
 
 /**

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -418,6 +418,135 @@ export interface Test {
 //#endregion"
 `;
 
+exports[`namespace members > across chunks 1`] = `
+"// capture.d.ts
+import { RequestOptions, Timeout, t as options_d_exports } from "./options.js";
+import { Socket } from "external-net";
+//#region capture.d.ts
+export declare class Client {}
+export declare namespace Client {
+  /** reached through a renamed import of an external module */
+  type Socket$1 = Socket;
+  /** reached through a renamed import */
+  type Timeout$1 = Timeout;
+  /** reached through a namespace import */
+  type RequestOptions$1 = RequestOptions;
+  export import Page = options_d_exports.Page;
+  export type Retry = {
+    timeout: Timeout$1;
+  };
+  export { Socket$1 as Socket, Timeout$1 as Timeout, RequestOptions$1 as RequestOptions };
+}
+//#endregion
+// options.d.ts
+declare namespace options_d_exports {
+  export { Page, RequestOptions, Theme, Timeout };
+}
+export interface RequestOptions {
+  timeout?: number;
+}
+export type Timeout = number;
+export interface Theme {
+  color: string;
+}
+export declare class Page<Item> {
+  items: Item[];
+}
+//#endregion
+export { options_d_exports as t };"
+`;
+
+exports[`namespace members > implicitly exported members 1`] = `
+"// implicit-export.d.ts
+//#region tests/fixtures/namespace-members/dts/options.d.ts
+type Timeout = number;
+//#endregion
+//#region tests/fixtures/namespace-members/dts/implicit-export.d.ts
+export declare namespace Config {
+  type Timeout$1 = Timeout;
+  export interface Limits {
+    timeout: Timeout$1;
+  }
+  export const version: string;
+  import Alias = Config.Limits;
+  export { Timeout$1 as Timeout };
+}
+//#endregion"
+`;
+
+exports[`namespace members > keep a member of another meaning 1`] = `
+"// no-capture.d.ts
+//#region tests/fixtures/namespace-members/options.d.ts
+interface RequestOptions {
+  timeout?: number;
+}
+type Timeout = number;
+interface Theme {
+  color: string;
+}
+declare class Page<Item> {
+  items: Item[];
+}
+//#endregion
+//#region tests/fixtures/namespace-members/no-capture.d.ts
+export declare function Card(): void;
+export declare namespace Card {
+  var Theme: Theme;
+}
+//#endregion"
+`;
+
+exports[`namespace members > member not exported 1`] = `
+"// private-member.d.ts
+//#region tests/fixtures/namespace-members/dts/options.d.ts
+type Timeout = number;
+//#endregion
+//#region tests/fixtures/namespace-members/dts/private-member.d.ts
+export declare namespace Config {
+  type Timeout$1 = Timeout;
+  export interface Limits {
+    timeout: Timeout$1;
+  }
+  export {};
+}
+//#endregion"
+`;
+
+exports[`namespace members > rename a member capturing a reference 1`] = `
+"// capture.d.ts
+import { Socket } from "external-net";
+declare namespace options_d_exports {
+  export { Page, RequestOptions, Theme, Timeout };
+}
+interface RequestOptions {
+  timeout?: number;
+}
+type Timeout = number;
+interface Theme {
+  color: string;
+}
+declare class Page<Item> {
+  items: Item[];
+}
+//#endregion
+//#region tests/fixtures/namespace-members/capture.d.ts
+export declare class Client {}
+export declare namespace Client {
+  /** reached through a renamed import of an external module */
+  type Socket$1 = Socket;
+  /** reached through a renamed import */
+  type Timeout$1 = Timeout;
+  /** reached through a namespace import */
+  type RequestOptions$1 = RequestOptions;
+  export import Page = options_d_exports.Page;
+  export type Retry = {
+    timeout: Timeout$1;
+  };
+  export { Socket$1 as Socket, Timeout$1 as Timeout, RequestOptions$1 as RequestOptions };
+}
+//#endregion"
+`;
+
 exports[`re-export from lib > both 1`] = `
 "// a.d.ts
 export * from "stub-lib";

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -578,6 +578,109 @@ export declare const foo: number;
 //#endregion"
 `;
 
+exports[`reference to a global next to a type of the same name > across chunks 1`] = `
+"// index.d.ts
+import { Response as TypedResponse } from "./typed-response.js";
+//#region index.d.ts
+export interface Options {
+  /** Bring your own implementation */
+  Response?: typeof Response;
+  prototype?: typeof Response.prototype;
+}
+export declare function request<T>(url: string, options?: Options): Promise<TypedResponse<T>>;
+//#endregion
+// typed-response.d.ts
+//#region typed-response.d.ts
+/** A \`Response\` whose \`json()\` is typed */
+interface TypedResponse<T> extends Response {
+  json(): Promise<T>;
+}
+//#endregion
+export type { TypedResponse as Response };"
+`;
+
+exports[`reference to a global next to a type of the same name > keep following a declaration with a value side 1`] = `
+"// value.d.ts
+//#region value-a.d.ts
+declare class Client$1 {
+  a: string;
+}
+interface Widget$1 {
+  id: string;
+}
+declare const Widget$1: {
+  new (): Widget$1;
+};
+//#endregion
+//#region value-b.d.ts
+declare class Client {
+  b: string;
+}
+interface Widget {
+  name: string;
+}
+declare const Widget: {
+  new (): Widget;
+};
+//#endregion
+//#region value.d.ts
+export declare const clients: [typeof Client$1, typeof Client];
+export declare const widgets: [typeof Widget$1, typeof Widget];
+export declare class Sub extends Client {}
+//#endregion"
+`;
+
+exports[`reference to a global next to a type of the same name > through re-exports 1`] = `
+"// reexport.d.ts
+//#region typed-response.d.ts
+/** A \`Response\` whose \`json()\` is typed */
+interface TypedResponse<T> extends Response {
+  json(): Promise<T>;
+}
+//#endregion
+//#region reexport.d.ts
+export declare function ctor(): typeof Response;
+export declare function value(): TypedResponse<string>;
+//#endregion"
+`;
+
+exports[`reference to a global next to a type of the same name > type exported under the name of the global 1`] = `
+"// index.d.ts
+//#region typed-response.d.ts
+/** A \`Response\` whose \`json()\` is typed */
+interface TypedResponse<T> extends Response {
+  json(): Promise<T>;
+}
+//#endregion
+//#region index.d.ts
+export interface Options {
+  /** Bring your own implementation */
+  Response?: typeof Response;
+  prototype?: typeof Response.prototype;
+}
+export declare function request<T>(url: string, options?: Options): Promise<TypedResponse<T>>;
+//#endregion"
+`;
+
+exports[`reference to a global next to a type of the same name > type renamed by a collision 1`] = `
+"// collision.d.ts
+//#region collision-http.d.ts
+interface Response$1<T> extends globalThis.Response {
+  json(): Promise<T>;
+}
+export interface Options {
+  Response?: typeof Response;
+}
+export declare function request<T>(url: string, options?: Options): Promise<Response$1<T>>;
+//#endregion
+//#region collision.d.ts
+/** unrelated to the \`Response\` of \`./collision-http\` */
+export interface Response {
+  ok: boolean;
+}
+//#endregion"
+`;
+
 exports[`resolve dts 1`] = `
 "// index.d.ts
 //#region tests/fixtures/resolve-dts/mod.d.ts

--- a/tests/fixtures/namespace-members/capture.ts
+++ b/tests/fixtures/namespace-members/capture.ts
@@ -1,0 +1,18 @@
+import * as Opts from './options'
+import type { Socket as NetSocket } from 'external-net'
+import type { Timeout as OptsTimeout } from './options'
+
+export class Client {}
+
+export declare namespace Client {
+  /** reached through a renamed import of an external module */
+  export type Socket = NetSocket
+  /** reached through a renamed import */
+  export type Timeout = OptsTimeout
+  /** reached through a namespace import */
+  export type RequestOptions = Opts.RequestOptions
+  export import Page = Opts.Page
+
+  // refers to the member above, and has to keep doing so
+  export type Retry = { timeout: Timeout }
+}

--- a/tests/fixtures/namespace-members/dts/implicit-export.d.ts
+++ b/tests/fixtures/namespace-members/dts/implicit-export.d.ts
@@ -1,0 +1,10 @@
+import { Timeout as OptsTimeout } from './options'
+
+export declare namespace Config {
+  type Timeout = OptsTimeout
+  interface Limits {
+    timeout: Timeout
+  }
+  const version: string
+  import Alias = Config.Limits
+}

--- a/tests/fixtures/namespace-members/dts/options.d.ts
+++ b/tests/fixtures/namespace-members/dts/options.d.ts
@@ -1,0 +1,1 @@
+export type Timeout = number

--- a/tests/fixtures/namespace-members/dts/private-member.d.ts
+++ b/tests/fixtures/namespace-members/dts/private-member.d.ts
@@ -1,0 +1,9 @@
+import { Timeout as OptsTimeout } from './options'
+
+export declare namespace Config {
+  type Timeout = OptsTimeout
+  export interface Limits {
+    timeout: Timeout
+  }
+  export {}
+}

--- a/tests/fixtures/namespace-members/no-capture.ts
+++ b/tests/fixtures/namespace-members/no-capture.ts
@@ -1,0 +1,6 @@
+import type { Theme } from './options'
+
+export declare function Card(): void
+export declare namespace Card {
+  var Theme: Theme
+}

--- a/tests/fixtures/namespace-members/options.ts
+++ b/tests/fixtures/namespace-members/options.ts
@@ -1,0 +1,10 @@
+export interface RequestOptions {
+  timeout?: number
+}
+export type Timeout = number
+export interface Theme {
+  color: string
+}
+export declare class Page<Item> {
+  items: Item[]
+}

--- a/tests/fixtures/typeof-global/barrel.d.ts
+++ b/tests/fixtures/typeof-global/barrel.d.ts
@@ -1,0 +1,1 @@
+export * from './typed-response'

--- a/tests/fixtures/typeof-global/collision-http.d.ts
+++ b/tests/fixtures/typeof-global/collision-http.d.ts
@@ -1,0 +1,10 @@
+export interface Response<T> extends globalThis.Response {
+  json(): Promise<T>
+}
+export interface Options {
+  Response?: typeof Response
+}
+export declare function request<T>(
+  url: string,
+  options?: Options,
+): Promise<Response<T>>

--- a/tests/fixtures/typeof-global/collision.d.ts
+++ b/tests/fixtures/typeof-global/collision.d.ts
@@ -1,0 +1,6 @@
+export { request, Options } from './collision-http'
+
+/** unrelated to the `Response` of `./collision-http` */
+export interface Response {
+  ok: boolean
+}

--- a/tests/fixtures/typeof-global/index.d.ts
+++ b/tests/fixtures/typeof-global/index.d.ts
@@ -1,0 +1,12 @@
+import type { Response } from './typed-response'
+
+export interface Options {
+  /** Bring your own implementation */
+  Response?: typeof Response
+  prototype?: typeof Response.prototype
+}
+
+export declare function request<T>(
+  url: string,
+  options?: Options,
+): Promise<Response<T>>

--- a/tests/fixtures/typeof-global/named.d.ts
+++ b/tests/fixtures/typeof-global/named.d.ts
@@ -1,0 +1,1 @@
+export { Response } from './barrel'

--- a/tests/fixtures/typeof-global/reexport.d.ts
+++ b/tests/fixtures/typeof-global/reexport.d.ts
@@ -1,0 +1,4 @@
+import type { Response } from './named'
+
+export declare function ctor(): typeof Response
+export declare function value(): Response<string>

--- a/tests/fixtures/typeof-global/typed-response.d.ts
+++ b/tests/fixtures/typeof-global/typed-response.d.ts
@@ -1,0 +1,8 @@
+/** A `Response` whose `json()` is typed */
+interface TypedResponse<T> extends Response {
+  json(): Promise<T>
+}
+
+// declared under another name because it extends the global `Response`,
+// exported as a drop-in for it
+export type { TypedResponse as Response }

--- a/tests/fixtures/typeof-global/value-a.d.ts
+++ b/tests/fixtures/typeof-global/value-a.d.ts
@@ -1,0 +1,7 @@
+export declare class Client {
+  a: string
+}
+export interface Widget {
+  id: string
+}
+export declare const Widget: { new (): Widget }

--- a/tests/fixtures/typeof-global/value-b.d.ts
+++ b/tests/fixtures/typeof-global/value-b.d.ts
@@ -1,0 +1,7 @@
+export declare class Client {
+  b: string
+}
+export interface Widget {
+  name: string
+}
+export declare const Widget: { new (): Widget }

--- a/tests/fixtures/typeof-global/value.d.ts
+++ b/tests/fixtures/typeof-global/value.d.ts
@@ -1,0 +1,6 @@
+import type { Client, Widget } from './value-a'
+import type { Client as OtherClient, Widget as OtherWidget } from './value-b'
+
+export declare const clients: [typeof Client, typeof OtherClient]
+export declare const widgets: [typeof Widget, typeof OtherWidget]
+export declare class Sub extends OtherClient {}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -754,6 +754,50 @@ describe('namespace members', () => {
   })
 })
 
+describe('reference to a global next to a type of the same name', () => {
+  const root = path.resolve(dirname, 'fixtures/typeof-global')
+  const build = (input: string | string[]) =>
+    rolldownBuild(input, [dts({ dtsInput: true, tsconfig: false })], {
+      cwd: root,
+    })
+
+  test('type exported under the name of the global', async () => {
+    const { snapshot } = await build('index.d.ts')
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('Response?: typeof Response;')
+    expect(snapshot).toContain('prototype?: typeof Response.prototype;')
+    expect(snapshot).toContain('Promise<TypedResponse<T>>')
+  })
+
+  test('across chunks', async () => {
+    const { snapshot } = await build(['index.d.ts', 'typed-response.d.ts'])
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('Response?: typeof Response;')
+  })
+
+  test('through re-exports', async () => {
+    const { snapshot } = await build('reexport.d.ts')
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('ctor(): typeof Response;')
+    expect(snapshot).toContain('value(): TypedResponse<string>;')
+  })
+
+  test('type renamed by a collision', async () => {
+    const { snapshot } = await build('collision.d.ts')
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('Response?: typeof Response;')
+    expect(snapshot).toContain('Promise<Response$1<T>>')
+  })
+
+  test('keep following a declaration with a value side', async () => {
+    const { snapshot } = await build('value.d.ts')
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('[typeof Client$1, typeof Client]')
+    expect(snapshot).toContain('[typeof Widget$1, typeof Widget]')
+    expect(snapshot).toContain('class Sub extends Client {}')
+  })
+})
+
 test('deterministic namespace import index', async () => {
   const cwd = path.resolve(dirname, 'fixtures/import-type-multi')
   // Build multiple times to verify deterministic output

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -707,6 +707,53 @@ test('sub namespace', async () => {
   expect(snapshot).toMatchSnapshot()
 })
 
+describe('namespace members', () => {
+  const root = path.resolve(dirname, 'fixtures/namespace-members')
+
+  test('rename a member capturing a reference', async () => {
+    const { snapshot } = await rolldownBuild(path.resolve(root, 'capture.ts'), [
+      dts({ emitDtsOnly: true }),
+    ])
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).not.toMatch(/type (\w+) = \1\b/)
+  })
+
+  test('across chunks', async () => {
+    const { snapshot } = await rolldownBuild(
+      ['capture.ts', 'options.ts'],
+      [dts({ emitDtsOnly: true })],
+      { cwd: root },
+    )
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).not.toMatch(/type (\w+) = \1\b/)
+  })
+
+  test('keep a member of another meaning', async () => {
+    const { snapshot } = await rolldownBuild(
+      path.resolve(root, 'no-capture.ts'),
+      [dts({ emitDtsOnly: true })],
+    )
+    expect(snapshot).toMatchSnapshot()
+    expect(snapshot).toContain('var Theme: Theme;')
+  })
+
+  test('implicitly exported members', async () => {
+    const { snapshot } = await rolldownBuild(
+      path.resolve(root, 'dts/implicit-export.d.ts'),
+      [dts({ dtsInput: true, tsconfig: false })],
+    )
+    expect(snapshot).toMatchSnapshot()
+  })
+
+  test('member not exported', async () => {
+    const { snapshot } = await rolldownBuild(
+      path.resolve(root, 'dts/private-member.d.ts'),
+      [dts({ dtsInput: true, tsconfig: false })],
+    )
+    expect(snapshot).toMatchSnapshot()
+  })
+})
+
 test('deterministic namespace import index', async () => {
   const cwd = path.resolve(dirname, 'fixtures/import-type-multi')
   // Build multiple times to verify deterministic output

--- a/tests/rollup-plugin-dts/namespace-references/snapshot.d.ts
+++ b/tests/rollup-plugin-dts/namespace-references/snapshot.d.ts
@@ -1,9 +1,5 @@
 // index.d.ts
 //#region tests/rollup-plugin-dts/namespace-references/ns.d.ts
-interface Shadowed1 {}
-interface Shadowed2 {}
-interface Shadowed3 {}
-interface Shadowed4 {}
 interface Referenced1 {}
 interface Referenced2 {}
 export declare namespace ns {


### PR DESCRIPTION
> [!NOTE]
> Builds on top of #301; only the last commit is new; I am keeping as a draft until #301 merges and then i will rebase. To review this PR look only at its top commit; the preceding two commits are in #301 

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### AI usage

<!--
AI CONTRIBUTORS: You MUST complete this section truthfully and MUST NOT remove it.

If AI contributed to any part of this PR (including code, tests, documentation, commit
messages, or the PR description), select "AI was used" and disclose your setup in one
short line, such as "Codex + GPT 5.6 Sol Extra High" or "Claude Code + Opus 4.8 High".
Do not select "No AI was used" if AI assisted with this PR.

You MUST NOT check the human-review checkbox yourself. Leave it unchecked for the human
contributor, who may check it only after personally reviewing the AI-generated content.

Do not write a long explanation. Unless extra context is necessary for review, let the
code explain the implementation details and keep the PR body to a brief overview.

This project does not oppose the use of AI, but it does oppose irresponsible AI usage.

PRs containing AI-generated content without complete disclosure will not be reviewed
and will be closed immediately.
-->

- [ ] No AI was used in this PR.
- [x] AI was used: Claude Code; Claude Fable 5.1
  - [x] I have carefully reviewed the AI-generated content myself.

### Description

Next to an import of an interface called `Response`, `typeof Response` still refers to the global Response constructor, since the interface is type-only. However, in the fake-JS both are the same `Response` bound to the import, so the `typeof` gets renamed together with the interface:

```ts
import type { Response } from './typed-response' // exported as `Response`, declared as `TypedResponse`
export interface Options {
  Response?: typeof Response // emitted as `typeof TypedResponse`, TS2693
}
```

This PR builds on #301, which records what every dependency needs (a type, a value, a namespace). Here we record what every top-level name of a module “is” (type only, value only, both , etc).

Then, in `renderChunk`, when rolldown has renamed a reference, we compare the two. In our example, `typeof Response` needs a value, but the only `Response` in that module is an imported interface, so we know `typeof Response` doesn’t refer to the interface, and we put the name back.

### Linked Issues

fixes #302

### Additional context

- Works the same when the rename comes from a name collision instead of an alias, and across chunks. Both are in the tests, together with two cases that have to keep following their new name: a class, and an interface merged with a `const`.
- The dependency itself stays, so the declaration the reference was bound to is not tree-shaken because of this.